### PR TITLE
feat: add pipeline ConnectRPC API and refactor CLI to use API client (Vibe Kanban)

### DIFF
--- a/api/proto/pipeline/v1/pipeline_service.proto
+++ b/api/proto/pipeline/v1/pipeline_service.proto
@@ -9,7 +9,7 @@ option go_package = "github.com/eslsoft/vocnet/pkg/api/pipeline/v1;pipelinev1";
 
 // PipelineService manages the vocabulary distillation pipeline.
 service PipelineService {
-  // ProcessWord runs the full pipeline for a given term.
+  // ProcessWord runs the full pipeline for a given term (synchronous).
   rpc ProcessWord(ProcessWordRequest) returns (ProcessWordResponse);
 
   // GetPipelineStatus returns the status of pipeline tasks for a word.
@@ -26,7 +26,29 @@ service PipelineService {
 
   // GetEvidence returns raw evidence for a word.
   rpc GetEvidence(GetEvidenceRequest) returns (GetEvidenceResponse);
+
+  // SubmitJob creates an async pipeline job for one or more terms.
+  rpc SubmitJob(SubmitJobRequest) returns (PipelineJob);
+
+  // GetJob returns the details of a pipeline job.
+  rpc GetJob(GetJobRequest) returns (PipelineJob);
+
+  // ListJobs returns a list of pipeline jobs.
+  rpc ListJobs(ListJobsRequest) returns (ListJobsResponse);
+
+  // CancelJob cancels a pending or running pipeline job.
+  rpc CancelJob(CancelJobRequest) returns (PipelineJob);
+
+  // ListDataSources returns the status of all pipeline data sources.
+  rpc ListDataSources(ListDataSourcesRequest) returns (ListDataSourcesResponse);
+
+  // DownloadDataSource downloads a specific data source.
+  rpc DownloadDataSource(DownloadDataSourceRequest) returns (DownloadDataSourceResponse);
 }
+
+// ---------------------------------------------------------------------------
+// Word-level pipeline RPCs
+// ---------------------------------------------------------------------------
 
 // ProcessWordRequest initiates pipeline processing for a word.
 message ProcessWordRequest {
@@ -74,6 +96,10 @@ message RetryPhaseRequest {
   string language = 2;
   int32 phase = 3; // Phase number to retry
 }
+
+// ---------------------------------------------------------------------------
+// Snapshot RPCs
+// ---------------------------------------------------------------------------
 
 // GetWordSnapshotRequest requests a word snapshot.
 message GetWordSnapshotRequest {
@@ -158,6 +184,10 @@ message ListWordSnapshotsResponse {
   int32 page_no = 3;
 }
 
+// ---------------------------------------------------------------------------
+// Evidence RPCs
+// ---------------------------------------------------------------------------
+
 // GetEvidenceRequest requests raw evidence for a word.
 message GetEvidenceRequest {
   string term = 1;
@@ -179,4 +209,94 @@ message Evidence {
   google.protobuf.Struct content = 4;   // Raw JSON response
   string schema_version = 5;
   google.protobuf.Timestamp fetched_at = 6;
+}
+
+// ---------------------------------------------------------------------------
+// Job management RPCs
+// ---------------------------------------------------------------------------
+
+// SubmitJobRequest creates an async pipeline job.
+message SubmitJobRequest {
+  // Exactly one of term, terms, or wordbook_name must be set.
+  string term = 1;                   // Single word submission
+  repeated string terms = 2;         // Batch term submission
+  string wordbook_name = 3;          // Built-in wordbook name or ID
+
+  string language = 4;               // Language code (default "en")
+  int32 tier = 5;                    // Priority tier (default 2)
+  string name = 6;                   // Optional custom job name
+}
+
+// PipelineJob represents an async pipeline processing job.
+message PipelineJob {
+  int64 id = 1;
+  string job_type = 2;              // SINGLE_WORD, WORDBOOK
+  string status = 3;                // PENDING, RUNNING, COMPLETED, FAILED, CANCELLED
+  string name = 4;
+  string language = 5;
+  int32 tier = 6;
+
+  // Progress tracking
+  int32 total_terms = 7;
+  int32 processed = 8;
+  int32 skipped = 9;
+  int32 failed = 10;
+
+  string error_message = 11;
+
+  google.protobuf.Timestamp started_at = 12;
+  google.protobuf.Timestamp completed_at = 13;
+  google.protobuf.Timestamp created_at = 14;
+}
+
+// GetJobRequest requests details of a specific job.
+message GetJobRequest {
+  int64 id = 1;
+}
+
+// ListJobsRequest requests a filtered list of pipeline jobs.
+message ListJobsRequest {
+  string status = 1;                 // Filter by status (empty = all)
+  int32 limit = 2;                   // Max results (default 50)
+}
+
+// ListJobsResponse contains a list of pipeline jobs.
+message ListJobsResponse {
+  repeated PipelineJob jobs = 1;
+}
+
+// CancelJobRequest cancels a pipeline job.
+message CancelJobRequest {
+  int64 id = 1;
+}
+
+// ---------------------------------------------------------------------------
+// Data source management RPCs
+// ---------------------------------------------------------------------------
+
+// ListDataSourcesRequest requests status of all data sources.
+message ListDataSourcesRequest {}
+
+// ListDataSourcesResponse contains data source statuses.
+message ListDataSourcesResponse {
+  repeated DataSourceStatus sources = 1;
+}
+
+// DataSourceStatus represents the status of a pipeline data source.
+message DataSourceStatus {
+  string name = 1;
+  string path = 2;
+  bool available = 3;
+  int64 size_bytes = 4;
+  string error_message = 5;
+}
+
+// DownloadDataSourceRequest requests download of a specific data source.
+message DownloadDataSourceRequest {
+  string name = 1;                   // Source name: conceptnet, ecdict, wordnet, moby (empty = all missing)
+}
+
+// DownloadDataSourceResponse confirms download completion.
+message DownloadDataSourceResponse {
+  repeated DataSourceStatus sources = 1; // Updated statuses after download
 }

--- a/api/proto/pipeline/v1/pipeline_service.proto
+++ b/api/proto/pipeline/v1/pipeline_service.proto
@@ -247,6 +247,8 @@ message PipelineJob {
   google.protobuf.Timestamp started_at = 12;
   google.protobuf.Timestamp completed_at = 13;
   google.protobuf.Timestamp created_at = 14;
+
+  string term = 15;                 // Target term (for SINGLE_WORD jobs)
 }
 
 // GetJobRequest requests details of a specific job.

--- a/cmd/pipeline.go
+++ b/cmd/pipeline.go
@@ -26,7 +26,8 @@ var pipelineCmd = &cobra.Command{
 }
 
 func newPipelineClient() pipelinev1connect.PipelineServiceClient {
-	return pipelinev1connect.NewPipelineServiceClient(http.DefaultClient, pipelineServerURL)
+	httpClient := &http.Client{Timeout: 30 * time.Second}
+	return pipelinev1connect.NewPipelineServiceClient(httpClient, pipelineServerURL)
 }
 
 // Source management commands
@@ -276,10 +277,9 @@ var jobCmd = &cobra.Command{
 		}
 
 		// Show stage details for single-word jobs via GetPipelineStatus
-		if j.GetJobType() == "SINGLE_WORD" {
-			// Extract term from the job name (format: "word: <term>")
-			term := strings.TrimPrefix(j.GetName(), "word: ")
-			if term != "" && term != j.GetName() {
+		if j.GetJobType() == "SINGLE_WORD" && j.GetTerm() != "" {
+			term := j.GetTerm()
+			{
 				statusResp, err := client.GetPipelineStatus(ctx, connect.NewRequest(&pipelinev1.GetPipelineStatusRequest{
 					Term:     term,
 					Language: j.GetLanguage(),
@@ -332,7 +332,7 @@ var cancelCmd = &cobra.Command{
 			return err
 		}
 
-		fmt.Printf("Job #%d cancelled (was: %s)\n", resp.Msg.GetId(), resp.Msg.GetStatus())
+		fmt.Printf("Job #%d cancelled (status: %s)\n", resp.Msg.GetId(), resp.Msg.GetStatus())
 		return nil
 	},
 }

--- a/cmd/pipeline.go
+++ b/cmd/pipeline.go
@@ -26,7 +26,7 @@ var pipelineCmd = &cobra.Command{
 }
 
 func newPipelineClient() pipelinev1connect.PipelineServiceClient {
-	httpClient := &http.Client{Timeout: 30 * time.Second}
+	httpClient := &http.Client{Timeout: 10 * time.Minute}
 	return pipelinev1connect.NewPipelineServiceClient(httpClient, pipelineServerURL)
 }
 

--- a/cmd/pipeline.go
+++ b/cmd/pipeline.go
@@ -3,27 +3,30 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"os"
 	"strconv"
 	"strings"
 	"time"
 
+	"connectrpc.com/connect"
 	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
 
-	"github.com/eslsoft/vocnet/internal/adapter/repository"
-	"github.com/eslsoft/vocnet/internal/entity"
-	"github.com/eslsoft/vocnet/internal/infrastructure/config"
-	"github.com/eslsoft/vocnet/internal/infrastructure/database"
-	"github.com/eslsoft/vocnet/internal/infrastructure/datasource"
-	"github.com/eslsoft/vocnet/internal/infrastructure/server"
 	"github.com/eslsoft/vocnet/internal/usecase/pipeline"
-	"github.com/eslsoft/vocnet/pkg/wordbook"
+	pipelinev1 "github.com/eslsoft/vocnet/pkg/api/pipeline/v1"
+	"github.com/eslsoft/vocnet/pkg/api/pipeline/v1/pipelinev1connect"
 )
+
+var pipelineServerURL string
 
 var pipelineCmd = &cobra.Command{
 	Use:   "pipeline",
 	Short: "Vocabulary distillation pipeline operations",
+}
+
+func newPipelineClient() pipelinev1connect.PipelineServiceClient {
+	return pipelinev1connect.NewPipelineServiceClient(http.DefaultClient, pipelineServerURL)
 }
 
 // Source management commands
@@ -36,50 +39,38 @@ var sourceListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List all data sources and their status",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		cfg, err := config.Load()
-		if err != nil {
-			return fmt.Errorf("load config: %w", err)
-		}
+		client := newPipelineClient()
+		ctx := context.Background()
 
-		logger, err := server.NewLogger(cfg)
+		resp, err := client.ListDataSources(ctx, connect.NewRequest(&pipelinev1.ListDataSourcesRequest{}))
 		if err != nil {
-			return fmt.Errorf("create logger: %w", err)
-		}
-
-		mgr := datasource.NewManager(cfg, logger, cfg.Pipeline.CacheDir)
-		statuses, err := mgr.CheckAll()
-		if err != nil {
-			return fmt.Errorf("check data sources: %w", err)
+			return fmt.Errorf("list data sources: %w", err)
 		}
 
 		fmt.Println("Pipeline Data Sources:")
 		table := tablewriter.NewTable(os.Stdout)
 		table.Header("STATUS", "SOURCE", "PATH", "INFO")
-		for _, status := range statuses {
+		var missing []string
+		for _, s := range resp.Msg.GetSources() {
 			symbol := "✗"
 			info := "not found"
-			if status.Available {
+			if s.GetAvailable() {
 				symbol = "✓"
-				if status.Size > 0 {
-					info = fmt.Sprintf("%.1f MB", float64(status.Size)/(1024*1024))
+				if s.GetSizeBytes() > 0 {
+					info = fmt.Sprintf("%.1f MB", float64(s.GetSizeBytes())/(1024*1024))
 				} else {
 					info = "verified"
 				}
-			} else if status.Exists {
-				info = fmt.Sprintf("invalid: %s", status.ErrorMsg)
+			} else if s.GetErrorMessage() != "" {
+				info = fmt.Sprintf("invalid: %s", s.GetErrorMessage())
 			}
 
-			_ = table.Append([]string{symbol, status.Name, status.Path, info})
+			_ = table.Append([]string{symbol, s.GetName(), s.GetPath(), info})
+			if !s.GetAvailable() {
+				missing = append(missing, strings.ToLower(s.GetName()))
+			}
 		}
 		_ = table.Render()
-
-		// Check if any missing
-		var missing []string
-		for _, status := range statuses {
-			if !status.Available {
-				missing = append(missing, strings.ToLower(status.Name))
-			}
-		}
 
 		if len(missing) > 0 {
 			fmt.Printf("\nTo download missing sources, run:\n")
@@ -105,23 +96,14 @@ Examples:
   vocnet pipeline source download conceptnet # Download only ConceptNet
   vocnet pipeline source download ecdict wordnet # Download ECDICT and WordNet`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		cfg, err := config.Load()
-		if err != nil {
-			return fmt.Errorf("load config: %w", err)
-		}
-
-		logger, err := server.NewLogger(cfg)
-		if err != nil {
-			return fmt.Errorf("create logger: %w", err)
-		}
-
-		mgr := datasource.NewManager(cfg, logger, cfg.Pipeline.CacheDir)
+		client := newPipelineClient()
 		ctx := context.Background()
 
-		// If no sources specified, download all missing
 		if len(args) == 0 {
+			// Download all missing
 			fmt.Println("Checking and downloading missing data sources...")
-			if err := mgr.DownloadMissing(ctx); err != nil {
+			_, err := client.DownloadDataSource(ctx, connect.NewRequest(&pipelinev1.DownloadDataSourceRequest{}))
+			if err != nil {
 				return fmt.Errorf("download missing: %w", err)
 			}
 			fmt.Println("\nAll data sources are now available.")
@@ -131,7 +113,10 @@ Examples:
 		// Download specific sources
 		for _, source := range args {
 			fmt.Printf("Downloading %s...\n", source)
-			if err := mgr.DownloadSource(ctx, source); err != nil {
+			_, err := client.DownloadDataSource(ctx, connect.NewRequest(&pipelinev1.DownloadDataSourceRequest{
+				Name: source,
+			}))
+			if err != nil {
 				return fmt.Errorf("download %s: %w", source, err)
 			}
 		}
@@ -160,15 +145,14 @@ File formats:
 		wb, _ := cmd.Flags().GetString("wordbook")
 		name, _ := cmd.Flags().GetString("name")
 
-		deps, err := newPipelineDeps()
-		if err != nil {
-			return err
-		}
-		defer deps.cleanup()
-
+		client := newPipelineClient()
 		ctx := context.Background()
 
-		var job *entity.PipelineJob
+		req := &pipelinev1.SubmitJobRequest{
+			Language: language,
+			Tier:     tier,
+			Name:     name,
+		}
 
 		switch {
 		case file != "":
@@ -176,34 +160,24 @@ File formats:
 			if err != nil {
 				return fmt.Errorf("parse file: %w", err)
 			}
-			job, err = deps.svc.SubmitTerms(ctx, name, terms, language, tier)
-			if err != nil {
-				return err
-			}
+			req.Terms = terms
 		case wb != "":
-			terms, wbName, err := resolveWordbook(wb)
-			if err != nil {
-				return err
-			}
-			if name == "" {
-				name = wbName
-			}
-			job, err = deps.svc.SubmitTerms(ctx, name, terms, language, tier)
-			if err != nil {
-				return err
-			}
+			req.WordbookName = wb
 		case len(args) > 0:
-			job, err = deps.svc.SubmitWord(ctx, args[0], language, tier)
-			if err != nil {
-				return err
-			}
+			req.Term = args[0]
 		default:
 			return fmt.Errorf("provide a term, --file, or --wordbook")
 		}
 
+		resp, err := client.SubmitJob(ctx, connect.NewRequest(req))
+		if err != nil {
+			return err
+		}
+
+		job := resp.Msg
 		fmt.Printf("Job #%d created: %s \"%s\" (%d terms)\n",
-			job.ID, job.JobType, job.Name, job.TotalTerms)
-		fmt.Printf("Use \"vocnet pipeline job %d\" to check progress.\n", job.ID)
+			job.GetId(), job.GetJobType(), job.GetName(), job.GetTotalTerms())
+		fmt.Printf("Use \"vocnet pipeline job %d\" to check progress.\n", job.GetId())
 		return nil
 	},
 }
@@ -215,55 +189,41 @@ var jobsCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		statusFlag, _ := cmd.Flags().GetString("status")
 
-		deps, err := newPipelineDeps()
-		if err != nil {
-			return err
-		}
-		defer deps.cleanup()
-
+		client := newPipelineClient()
 		ctx := context.Background()
 
-		var statusFilter *entity.JobStatus
-		if statusFlag != "" {
-			s := entity.JobStatus(strings.ToUpper(statusFlag))
-			statusFilter = &s
-		}
-
-		jobs, err := deps.svc.ListJobs(ctx, statusFilter)
+		resp, err := client.ListJobs(ctx, connect.NewRequest(&pipelinev1.ListJobsRequest{
+			Status: statusFlag,
+		}))
 		if err != nil {
 			return err
 		}
 
+		jobs := resp.Msg.GetJobs()
 		if len(jobs) == 0 {
 			fmt.Println("No jobs found.")
 			return nil
 		}
 
 		table := tablewriter.NewTable(os.Stdout)
-		table.Header("ID", "TYPE", "STATUS", "PROGRESS", "STAGES", "NAME", "CREATED")
+		table.Header("ID", "TYPE", "STATUS", "PROGRESS", "NAME", "CREATED")
 		for _, j := range jobs {
-			progress := fmt.Sprintf("%d/%d", j.Processed+j.Skipped+j.Failed, j.TotalTerms)
-			displayName := j.Name
+			progress := fmt.Sprintf("%d/%d", j.GetProcessed()+j.GetSkipped()+j.GetFailed(), j.GetTotalTerms())
+			displayName := j.GetName()
 			if len(displayName) > 30 {
 				displayName = displayName[:27] + "..."
 			}
-
-			stages := "-"
-			if j.JobType == entity.JobTypeSingleWord {
-				sp, err := deps.svc.GetJobStageProgress(ctx, j)
-				if err == nil && sp != nil {
-					stages = sp.String()
-				}
+			createdAt := ""
+			if j.GetCreatedAt() != nil {
+				createdAt = j.GetCreatedAt().AsTime().Format("2006-01-02 15:04")
 			}
-
 			_ = table.Append([]string{
-				strconv.FormatInt(j.ID, 10),
-				string(j.JobType),
-				string(j.Status),
+				strconv.FormatInt(j.GetId(), 10),
+				j.GetJobType(),
+				j.GetStatus(),
 				progress,
-				stages,
 				displayName,
-				j.CreatedAt.Format("2006-01-02 15:04"),
+				createdAt,
 			})
 		}
 		_ = table.Render()
@@ -282,132 +242,106 @@ var jobCmd = &cobra.Command{
 			return fmt.Errorf("invalid job ID: %w", err)
 		}
 
-		deps, err := newPipelineDeps()
-		if err != nil {
-			return err
-		}
-		defer deps.cleanup()
-
+		client := newPipelineClient()
 		ctx := context.Background()
 
-		detail, err := deps.svc.GetJobDetail(ctx, id)
+		resp, err := client.GetJob(ctx, connect.NewRequest(&pipelinev1.GetJobRequest{Id: id}))
 		if err != nil {
 			return fmt.Errorf("get job: %w", err)
 		}
 
-		j := detail.Job
-		fmt.Printf("Job #%d: %s\n", j.ID, j.Name)
-		fmt.Printf("Type:      %s\n", j.JobType)
-		fmt.Printf("Status:    %s\n", j.Status)
-		fmt.Printf("Language:  %s\n", j.Language)
-		fmt.Printf("Tier:      %d\n", j.Tier)
+		j := resp.Msg
+		fmt.Printf("Job #%d: %s\n", j.GetId(), j.GetName())
+		fmt.Printf("Type:      %s\n", j.GetJobType())
+		fmt.Printf("Status:    %s\n", j.GetStatus())
+		fmt.Printf("Language:  %s\n", j.GetLanguage())
+		fmt.Printf("Tier:      %d\n", j.GetTier())
 		fmt.Printf("Progress:  %d/%d processed, %d skipped, %d failed\n",
-			j.Processed, j.TotalTerms, j.Skipped, j.Failed)
-		fmt.Printf("Created:   %s\n", j.CreatedAt.Format("2006-01-02 15:04:05"))
-		if j.StartedAt != nil {
-			fmt.Printf("Started:   %s\n", j.StartedAt.Format("2006-01-02 15:04:05"))
+			j.GetProcessed(), j.GetTotalTerms(), j.GetSkipped(), j.GetFailed())
+		if j.GetCreatedAt() != nil {
+			fmt.Printf("Created:   %s\n", j.GetCreatedAt().AsTime().Format("2006-01-02 15:04:05"))
 		}
-		if j.CompletedAt != nil {
-			fmt.Printf("Completed: %s\n", j.CompletedAt.Format("2006-01-02 15:04:05"))
+		if j.GetStartedAt() != nil {
+			fmt.Printf("Started:   %s\n", j.GetStartedAt().AsTime().Format("2006-01-02 15:04:05"))
 		}
-		if j.StartedAt != nil && j.CompletedAt != nil {
-			duration := j.CompletedAt.Sub(*j.StartedAt)
+		if j.GetCompletedAt() != nil {
+			fmt.Printf("Completed: %s\n", j.GetCompletedAt().AsTime().Format("2006-01-02 15:04:05"))
+		}
+		if j.GetStartedAt() != nil && j.GetCompletedAt() != nil {
+			duration := j.GetCompletedAt().AsTime().Sub(j.GetStartedAt().AsTime())
 			fmt.Printf("Duration:  %s\n", duration.Truncate(100*time.Millisecond))
 		}
-		if j.ErrorMessage != "" {
-			fmt.Printf("Error:     %s\n", j.ErrorMessage)
+		if j.GetErrorMessage() != "" {
+			fmt.Printf("Error:     %s\n", j.GetErrorMessage())
 		}
 
-		// Show stage details for single-word jobs
-		if len(detail.Tasks) > 0 {
-			fmt.Println("\nStages:")
-			table := tablewriter.NewTable(os.Stdout)
-			table.Header("PHASE", "NAME", "STATUS", "DURATION")
-			for _, task := range detail.Tasks {
-				phase := entity.PipelinePhase(task.Phase)
-				dur := "-"
-				if task.StartedAt != nil && task.CompletedAt != nil {
-					dur = task.CompletedAt.Sub(*task.StartedAt).Truncate(100 * time.Millisecond).String()
-				}
-				_ = table.Append([]string{
-					strconv.Itoa(int(task.Phase)),
-					phase.Name(),
-					string(task.Status),
-					dur,
-				})
-				if task.ErrorMessage != "" {
-					_ = table.Append([]string{"", "", fmt.Sprintf("  error: %s", task.ErrorMessage), ""})
+		// Show stage details for single-word jobs via GetPipelineStatus
+		if j.GetJobType() == "SINGLE_WORD" {
+			// Extract term from the job name (format: "word: <term>")
+			term := strings.TrimPrefix(j.GetName(), "word: ")
+			if term != "" && term != j.GetName() {
+				statusResp, err := client.GetPipelineStatus(ctx, connect.NewRequest(&pipelinev1.GetPipelineStatusRequest{
+					Term:     term,
+					Language: j.GetLanguage(),
+				}))
+				if err == nil && len(statusResp.Msg.GetPhases()) > 0 {
+					fmt.Println("\nStages:")
+					stageTable := tablewriter.NewTable(os.Stdout)
+					stageTable.Header("PHASE", "NAME", "STATUS", "DURATION")
+					for _, phase := range statusResp.Msg.GetPhases() {
+						dur := "-"
+						if phase.GetStartedAt() != nil && phase.GetCompletedAt() != nil {
+							d := phase.GetCompletedAt().AsTime().Sub(phase.GetStartedAt().AsTime())
+							dur = d.Truncate(100 * time.Millisecond).String()
+						}
+						_ = stageTable.Append([]string{
+							strconv.Itoa(int(phase.GetPhase())),
+							phase.GetName(),
+							phase.GetStatus(),
+							dur,
+						})
+						if phase.GetErrorMessage() != "" {
+							_ = stageTable.Append([]string{"", "", fmt.Sprintf("  error: %s", phase.GetErrorMessage()), ""})
+						}
+					}
+					_ = stageTable.Render()
 				}
 			}
-			_ = table.Render()
 		}
 
 		return nil
 	},
 }
 
-// pipelineDeps bundles CLI dependencies for pipeline commands.
-type pipelineDeps struct {
-	svc     *pipeline.PipelineService
-	cleanup func()
-}
-
-// newPipelineDeps creates the common dependencies for pipeline CLI commands.
-func newPipelineDeps() (*pipelineDeps, error) {
-	cfg, err := config.Load()
-	if err != nil {
-		return nil, fmt.Errorf("load config: %w", err)
-	}
-
-	logger, err := server.NewLogger(cfg)
-	if err != nil {
-		return nil, fmt.Errorf("create logger: %w", err)
-	}
-
-	entClient, cleanup, err := database.NewEntClient(cfg)
-	if err != nil {
-		return nil, fmt.Errorf("create ent client: %w", err)
-	}
-
-	jobRepo := repository.NewPipelineJobRepository(entClient)
-	taskRepo := repository.NewPipelineTaskRepository(entClient)
-	lemmaRepo := repository.NewLemmaRepository(entClient)
-	svc := pipeline.NewPipelineService(jobRepo, taskRepo, lemmaRepo, logger)
-
-	return &pipelineDeps{svc: svc, cleanup: cleanup}, nil
-}
-
-// resolveWordbook finds a builtin wordbook by name or ID and returns its terms.
-func resolveWordbook(nameOrID string) ([]string, string, error) {
-	builtins := wordbook.GetBuiltinWordbooks()
-
-	// Try by ID
-	if id, err := strconv.ParseInt(nameOrID, 10, 64); err == nil {
-		for _, wb := range builtins {
-			if wb.Id == id {
-				return wb.Terms, wb.Name, nil
-			}
+// cancelCmd cancels a pending or running pipeline job
+var cancelCmd = &cobra.Command{
+	Use:   "cancel <id>",
+	Short: "Cancel a pending or running pipeline job",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		id, err := strconv.ParseInt(args[0], 10, 64)
+		if err != nil {
+			return fmt.Errorf("invalid job ID: %w", err)
 		}
-		return nil, "", fmt.Errorf("wordbook with ID %d not found", id)
-	}
 
-	// Try by name (case-insensitive)
-	for _, wb := range builtins {
-		if strings.EqualFold(wb.Name, nameOrID) {
-			return wb.Terms, wb.Name, nil
+		client := newPipelineClient()
+		ctx := context.Background()
+
+		resp, err := client.CancelJob(ctx, connect.NewRequest(&pipelinev1.CancelJobRequest{Id: id}))
+		if err != nil {
+			return err
 		}
-	}
 
-	// List available
-	var names []string
-	for _, wb := range builtins {
-		names = append(names, fmt.Sprintf("  %d: %s (%d terms)", wb.Id, wb.Name, len(wb.Terms)))
-	}
-	return nil, "", fmt.Errorf("wordbook %q not found. Available:\n%s", nameOrID, strings.Join(names, "\n"))
+		fmt.Printf("Job #%d cancelled (was: %s)\n", resp.Msg.GetId(), resp.Msg.GetStatus())
+		return nil
+	},
 }
 
 func init() {
 	rootCmd.AddCommand(pipelineCmd)
+
+	// Server URL flag on the pipeline command (inherited by subcommands)
+	pipelineCmd.PersistentFlags().StringVar(&pipelineServerURL, "server", "http://localhost:8080", "Pipeline API server URL")
 
 	// Source management commands
 	pipelineCmd.AddCommand(sourceCmd)
@@ -425,4 +359,5 @@ func init() {
 	jobsCmd.Flags().String("status", "", "Filter by status (PENDING, RUNNING, COMPLETED, FAILED)")
 
 	pipelineCmd.AddCommand(jobCmd)
+	pipelineCmd.AddCommand(cancelCmd)
 }

--- a/internal/adapter/connectrpc/pipeline_service.go
+++ b/internal/adapter/connectrpc/pipeline_service.go
@@ -1,0 +1,279 @@
+package connectrpc
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"connectrpc.com/connect"
+	"github.com/eslsoft/vocnet/internal/adapter/mapping"
+	"github.com/eslsoft/vocnet/internal/entity"
+	"github.com/eslsoft/vocnet/internal/infrastructure/datasource"
+	"github.com/eslsoft/vocnet/internal/repository"
+	"github.com/eslsoft/vocnet/internal/usecase/pipeline"
+	pipelinev1 "github.com/eslsoft/vocnet/pkg/api/pipeline/v1"
+	"github.com/eslsoft/vocnet/pkg/api/pipeline/v1/pipelinev1connect"
+	"github.com/eslsoft/vocnet/pkg/wordbook"
+	"github.com/samber/lo"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+var _ pipelinev1connect.PipelineServiceHandler = (*PipelineServiceServer)(nil)
+
+// PipelineServiceServer implements the PipelineService ConnectRPC handler.
+type PipelineServiceServer struct {
+	pipelinev1connect.UnimplementedPipelineServiceHandler
+
+	svc *pipeline.PipelineService
+}
+
+// NewPipelineServiceServer creates a new PipelineServiceServer.
+func NewPipelineServiceServer(svc *pipeline.PipelineService) *PipelineServiceServer {
+	return &PipelineServiceServer{svc: svc}
+}
+
+// ---------------------------------------------------------------------------
+// Word-level pipeline RPCs
+// ---------------------------------------------------------------------------
+
+func (s *PipelineServiceServer) ProcessWord(_ context.Context, _ *connect.Request[pipelinev1.ProcessWordRequest]) (*connect.Response[pipelinev1.ProcessWordResponse], error) {
+	// ProcessWord is a synchronous pipeline execution. This requires the full Pipeline
+	// orchestrator (not just PipelineService). For now, return unimplemented.
+	// In the future, this could be wired to Pipeline.Run() directly.
+	return nil, connect.NewError(connect.CodeUnimplemented, nil)
+}
+
+func (s *PipelineServiceServer) GetPipelineStatus(ctx context.Context, req *connect.Request[pipelinev1.GetPipelineStatusRequest]) (*connect.Response[pipelinev1.PipelineStatus], error) {
+	if req.Msg == nil || strings.TrimSpace(req.Msg.GetTerm()) == "" {
+		return nil, status.Error(codes.InvalidArgument, "term is required")
+	}
+
+	lemma, tasks, err := s.svc.GetPipelineStatus(ctx, req.Msg.GetTerm(), req.Msg.GetLanguage())
+	if err != nil {
+		return nil, mapping.ToPbError(err)
+	}
+
+	return connect.NewResponse(mapping.ToPbPipelineStatus(lemma, tasks)), nil
+}
+
+func (s *PipelineServiceServer) RetryPhase(_ context.Context, _ *connect.Request[pipelinev1.RetryPhaseRequest]) (*connect.Response[pipelinev1.PipelineStatus], error) {
+	// RetryPhase requires the full Pipeline orchestrator. Return unimplemented for now.
+	return nil, connect.NewError(connect.CodeUnimplemented, nil)
+}
+
+// ---------------------------------------------------------------------------
+// Snapshot RPCs
+// ---------------------------------------------------------------------------
+
+func (s *PipelineServiceServer) GetWordSnapshot(ctx context.Context, req *connect.Request[pipelinev1.GetWordSnapshotRequest]) (*connect.Response[pipelinev1.WordSnapshotResponse], error) {
+	if req.Msg == nil || strings.TrimSpace(req.Msg.GetTerm()) == "" {
+		return nil, status.Error(codes.InvalidArgument, "term is required")
+	}
+
+	snapshot, err := s.svc.GetWordSnapshot(ctx, req.Msg.GetTerm(), req.Msg.GetLanguage())
+	if err != nil {
+		return nil, mapping.ToPbError(err)
+	}
+
+	return connect.NewResponse(mapping.ToPbWordSnapshot(snapshot)), nil
+}
+
+func (s *PipelineServiceServer) ListWordSnapshots(ctx context.Context, req *connect.Request[pipelinev1.ListWordSnapshotsRequest]) (*connect.Response[pipelinev1.ListWordSnapshotsResponse], error) {
+	if req.Msg == nil {
+		return nil, status.Error(codes.InvalidArgument, "request required")
+	}
+
+	query := &repository.ListSnapshotsQuery{
+		Language:  req.Msg.GetLanguage(),
+		MinQScore: req.Msg.GetMinQscore(),
+		OrderBy:   req.Msg.GetOrderBy(),
+		Desc:      req.Msg.GetDesc(),
+		PageSize:  req.Msg.GetPageSize(),
+		PageNo:    req.Msg.GetPageNo(),
+	}
+
+	snapshots, total, err := s.svc.ListWordSnapshots(ctx, query)
+	if err != nil {
+		return nil, mapping.ToPbError(err)
+	}
+
+	return connect.NewResponse(&pipelinev1.ListWordSnapshotsResponse{
+		Snapshots: lo.Map(snapshots, func(snap *entity.WordSnapshot, _ int) *pipelinev1.WordSnapshotResponse {
+			return mapping.ToPbWordSnapshot(snap)
+		}),
+		Total:  int32(total),
+		PageNo: query.PageNo,
+	}), nil
+}
+
+// ---------------------------------------------------------------------------
+// Evidence RPCs
+// ---------------------------------------------------------------------------
+
+func (s *PipelineServiceServer) GetEvidence(ctx context.Context, req *connect.Request[pipelinev1.GetEvidenceRequest]) (*connect.Response[pipelinev1.GetEvidenceResponse], error) {
+	if req.Msg == nil || strings.TrimSpace(req.Msg.GetTerm()) == "" {
+		return nil, status.Error(codes.InvalidArgument, "term is required")
+	}
+
+	evidences, err := s.svc.GetEvidence(ctx, req.Msg.GetTerm(), req.Msg.GetLanguage(), req.Msg.GetPhase(), req.Msg.GetProvider())
+	if err != nil {
+		return nil, mapping.ToPbError(err)
+	}
+
+	return connect.NewResponse(&pipelinev1.GetEvidenceResponse{
+		Evidences: lo.Map(evidences, func(e *entity.RawEvidence, _ int) *pipelinev1.Evidence {
+			return mapping.ToPbEvidence(e)
+		}),
+	}), nil
+}
+
+// ---------------------------------------------------------------------------
+// Job management RPCs
+// ---------------------------------------------------------------------------
+
+func (s *PipelineServiceServer) SubmitJob(ctx context.Context, req *connect.Request[pipelinev1.SubmitJobRequest]) (*connect.Response[pipelinev1.PipelineJob], error) {
+	if req.Msg == nil {
+		return nil, status.Error(codes.InvalidArgument, "request required")
+	}
+
+	msg := req.Msg
+	term := strings.TrimSpace(msg.GetTerm())
+	terms := msg.GetTerms()
+	wbName := strings.TrimSpace(msg.GetWordbookName())
+	language := msg.GetLanguage()
+	tier := msg.GetTier()
+	name := msg.GetName()
+
+	var job *entity.PipelineJob
+	var err error
+
+	switch {
+	case wbName != "":
+		// Resolve wordbook to terms
+		resolvedTerms, resolvedName, resolveErr := resolveWordbook(wbName)
+		if resolveErr != nil {
+			return nil, connect.NewError(connect.CodeInvalidArgument, resolveErr)
+		}
+		if name == "" {
+			name = resolvedName
+		}
+		job, err = s.svc.SubmitTerms(ctx, name, resolvedTerms, language, tier)
+	case len(terms) > 0:
+		job, err = s.svc.SubmitTerms(ctx, name, terms, language, tier)
+	case term != "":
+		job, err = s.svc.SubmitWord(ctx, term, language, tier)
+	default:
+		return nil, status.Error(codes.InvalidArgument, "one of term, terms, or wordbook_name is required")
+	}
+
+	if err != nil {
+		return nil, mapping.ToPbError(err)
+	}
+
+	return connect.NewResponse(mapping.ToPbPipelineJob(job)), nil
+}
+
+func (s *PipelineServiceServer) GetJob(ctx context.Context, req *connect.Request[pipelinev1.GetJobRequest]) (*connect.Response[pipelinev1.PipelineJob], error) {
+	if req.Msg == nil || req.Msg.GetId() == 0 {
+		return nil, status.Error(codes.InvalidArgument, "job id is required")
+	}
+
+	job, err := s.svc.GetJob(ctx, req.Msg.GetId())
+	if err != nil {
+		return nil, mapping.ToPbError(err)
+	}
+
+	return connect.NewResponse(mapping.ToPbPipelineJob(job)), nil
+}
+
+func (s *PipelineServiceServer) ListJobs(ctx context.Context, req *connect.Request[pipelinev1.ListJobsRequest]) (*connect.Response[pipelinev1.ListJobsResponse], error) {
+	if req.Msg == nil {
+		return nil, status.Error(codes.InvalidArgument, "request required")
+	}
+
+	var statusFilter *entity.JobStatus
+	if s := strings.TrimSpace(req.Msg.GetStatus()); s != "" {
+		js := entity.JobStatus(strings.ToUpper(s))
+		statusFilter = &js
+	}
+
+	limit := int(req.Msg.GetLimit())
+	jobs, err := s.svc.ListJobs(ctx, statusFilter, limit)
+	if err != nil {
+		return nil, mapping.ToPbError(err)
+	}
+
+	return connect.NewResponse(&pipelinev1.ListJobsResponse{
+		Jobs: lo.Map(jobs, func(j *entity.PipelineJob, _ int) *pipelinev1.PipelineJob {
+			return mapping.ToPbPipelineJob(j)
+		}),
+	}), nil
+}
+
+func (s *PipelineServiceServer) CancelJob(ctx context.Context, req *connect.Request[pipelinev1.CancelJobRequest]) (*connect.Response[pipelinev1.PipelineJob], error) {
+	if req.Msg == nil || req.Msg.GetId() == 0 {
+		return nil, status.Error(codes.InvalidArgument, "job id is required")
+	}
+
+	job, err := s.svc.CancelJob(ctx, req.Msg.GetId())
+	if err != nil {
+		return nil, mapping.ToPbError(err)
+	}
+
+	return connect.NewResponse(mapping.ToPbPipelineJob(job)), nil
+}
+
+// ---------------------------------------------------------------------------
+// Data source management RPCs
+// ---------------------------------------------------------------------------
+
+func (s *PipelineServiceServer) ListDataSources(ctx context.Context, _ *connect.Request[pipelinev1.ListDataSourcesRequest]) (*connect.Response[pipelinev1.ListDataSourcesResponse], error) {
+	statuses, err := s.svc.ListDataSources(ctx)
+	if err != nil {
+		return nil, mapping.ToPbError(err)
+	}
+
+	return connect.NewResponse(&pipelinev1.ListDataSourcesResponse{
+		Sources: lo.Map(statuses, func(st datasource.Status, _ int) *pipelinev1.DataSourceStatus {
+			return mapping.ToPbDataSourceStatus(st)
+		}),
+	}), nil
+}
+
+func (s *PipelineServiceServer) DownloadDataSource(ctx context.Context, req *connect.Request[pipelinev1.DownloadDataSourceRequest]) (*connect.Response[pipelinev1.DownloadDataSourceResponse], error) {
+	name := ""
+	if req.Msg != nil {
+		name = strings.TrimSpace(req.Msg.GetName())
+	}
+
+	statuses, err := s.svc.DownloadDataSource(ctx, name)
+	if err != nil {
+		return nil, mapping.ToPbError(err)
+	}
+
+	return connect.NewResponse(&pipelinev1.DownloadDataSourceResponse{
+		Sources: lo.Map(statuses, func(st datasource.Status, _ int) *pipelinev1.DataSourceStatus {
+			return mapping.ToPbDataSourceStatus(st)
+		}),
+	}), nil
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// resolveWordbook finds a builtin wordbook by name or ID and returns its terms.
+func resolveWordbook(nameOrID string) ([]string, string, error) {
+	builtins := wordbook.GetBuiltinWordbooks()
+
+	// Try by name (case-insensitive)
+	for _, wb := range builtins {
+		if strings.EqualFold(wb.Name, nameOrID) {
+			return wb.Terms, wb.Name, nil
+		}
+	}
+
+	return nil, "", fmt.Errorf("wordbook %q not found", nameOrID)
+}

--- a/internal/adapter/connectrpc/pipeline_service.go
+++ b/internal/adapter/connectrpc/pipeline_service.go
@@ -8,8 +8,6 @@ import (
 
 	"connectrpc.com/connect"
 	"github.com/samber/lo"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 
 	"github.com/eslsoft/vocnet/internal/adapter/mapping"
 	"github.com/eslsoft/vocnet/internal/entity"
@@ -48,7 +46,7 @@ func (s *PipelineServiceServer) ProcessWord(_ context.Context, _ *connect.Reques
 
 func (s *PipelineServiceServer) GetPipelineStatus(ctx context.Context, req *connect.Request[pipelinev1.GetPipelineStatusRequest]) (*connect.Response[pipelinev1.PipelineStatus], error) {
 	if req.Msg == nil || strings.TrimSpace(req.Msg.GetTerm()) == "" {
-		return nil, status.Error(codes.InvalidArgument, "term is required")
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("term is required"))
 	}
 
 	lemma, tasks, err := s.svc.GetPipelineStatus(ctx, req.Msg.GetTerm(), req.Msg.GetLanguage())
@@ -70,7 +68,7 @@ func (s *PipelineServiceServer) RetryPhase(_ context.Context, _ *connect.Request
 
 func (s *PipelineServiceServer) GetWordSnapshot(ctx context.Context, req *connect.Request[pipelinev1.GetWordSnapshotRequest]) (*connect.Response[pipelinev1.WordSnapshotResponse], error) {
 	if req.Msg == nil || strings.TrimSpace(req.Msg.GetTerm()) == "" {
-		return nil, status.Error(codes.InvalidArgument, "term is required")
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("term is required"))
 	}
 
 	snapshot, err := s.svc.GetWordSnapshot(ctx, req.Msg.GetTerm(), req.Msg.GetLanguage())
@@ -83,7 +81,7 @@ func (s *PipelineServiceServer) GetWordSnapshot(ctx context.Context, req *connec
 
 func (s *PipelineServiceServer) ListWordSnapshots(ctx context.Context, req *connect.Request[pipelinev1.ListWordSnapshotsRequest]) (*connect.Response[pipelinev1.ListWordSnapshotsResponse], error) {
 	if req.Msg == nil {
-		return nil, status.Error(codes.InvalidArgument, "request required")
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("request required"))
 	}
 
 	query := &repository.ListSnapshotsQuery{
@@ -115,7 +113,7 @@ func (s *PipelineServiceServer) ListWordSnapshots(ctx context.Context, req *conn
 
 func (s *PipelineServiceServer) GetEvidence(ctx context.Context, req *connect.Request[pipelinev1.GetEvidenceRequest]) (*connect.Response[pipelinev1.GetEvidenceResponse], error) {
 	if req.Msg == nil || strings.TrimSpace(req.Msg.GetTerm()) == "" {
-		return nil, status.Error(codes.InvalidArgument, "term is required")
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("term is required"))
 	}
 
 	evidences, err := s.svc.GetEvidence(ctx, req.Msg.GetTerm(), req.Msg.GetLanguage(), req.Msg.GetPhase(), req.Msg.GetProvider())
@@ -136,7 +134,7 @@ func (s *PipelineServiceServer) GetEvidence(ctx context.Context, req *connect.Re
 
 func (s *PipelineServiceServer) SubmitJob(ctx context.Context, req *connect.Request[pipelinev1.SubmitJobRequest]) (*connect.Response[pipelinev1.PipelineJob], error) {
 	if req.Msg == nil {
-		return nil, status.Error(codes.InvalidArgument, "request required")
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("request required"))
 	}
 
 	msg := req.Msg
@@ -146,6 +144,21 @@ func (s *PipelineServiceServer) SubmitJob(ctx context.Context, req *connect.Requ
 	language := msg.GetLanguage()
 	tier := msg.GetTier()
 	name := msg.GetName()
+
+	// Enforce mutual exclusivity: exactly one of term, terms, or wordbook_name
+	setCount := 0
+	if term != "" {
+		setCount++
+	}
+	if len(terms) > 0 {
+		setCount++
+	}
+	if wbName != "" {
+		setCount++
+	}
+	if setCount > 1 {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("exactly one of term, terms, or wordbook_name must be set"))
+	}
 
 	var job *entity.PipelineJob
 	var err error
@@ -166,7 +179,7 @@ func (s *PipelineServiceServer) SubmitJob(ctx context.Context, req *connect.Requ
 	case term != "":
 		job, err = s.svc.SubmitWord(ctx, term, language, tier)
 	default:
-		return nil, status.Error(codes.InvalidArgument, "one of term, terms, or wordbook_name is required")
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("one of term, terms, or wordbook_name is required"))
 	}
 
 	if err != nil {
@@ -179,7 +192,7 @@ func (s *PipelineServiceServer) SubmitJob(ctx context.Context, req *connect.Requ
 //nolint:dupl // GetJob and CancelJob are distinct RPCs with identical structure
 func (s *PipelineServiceServer) GetJob(ctx context.Context, req *connect.Request[pipelinev1.GetJobRequest]) (*connect.Response[pipelinev1.PipelineJob], error) {
 	if req.Msg == nil || req.Msg.GetId() == 0 {
-		return nil, status.Error(codes.InvalidArgument, "job id is required")
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("job id is required"))
 	}
 
 	job, err := s.svc.GetJob(ctx, req.Msg.GetId())
@@ -192,7 +205,7 @@ func (s *PipelineServiceServer) GetJob(ctx context.Context, req *connect.Request
 
 func (s *PipelineServiceServer) ListJobs(ctx context.Context, req *connect.Request[pipelinev1.ListJobsRequest]) (*connect.Response[pipelinev1.ListJobsResponse], error) {
 	if req.Msg == nil {
-		return nil, status.Error(codes.InvalidArgument, "request required")
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("request required"))
 	}
 
 	var statusFilter *entity.JobStatus
@@ -217,7 +230,7 @@ func (s *PipelineServiceServer) ListJobs(ctx context.Context, req *connect.Reque
 //nolint:dupl // CancelJob and GetJob are distinct RPCs with identical structure
 func (s *PipelineServiceServer) CancelJob(ctx context.Context, req *connect.Request[pipelinev1.CancelJobRequest]) (*connect.Response[pipelinev1.PipelineJob], error) {
 	if req.Msg == nil || req.Msg.GetId() == 0 {
-		return nil, status.Error(codes.InvalidArgument, "job id is required")
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("job id is required"))
 	}
 
 	job, err := s.svc.CancelJob(ctx, req.Msg.GetId())

--- a/internal/adapter/connectrpc/pipeline_service.go
+++ b/internal/adapter/connectrpc/pipeline_service.go
@@ -3,9 +3,14 @@ package connectrpc
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"connectrpc.com/connect"
+	"github.com/samber/lo"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
 	"github.com/eslsoft/vocnet/internal/adapter/mapping"
 	"github.com/eslsoft/vocnet/internal/entity"
 	"github.com/eslsoft/vocnet/internal/infrastructure/datasource"
@@ -14,10 +19,6 @@ import (
 	pipelinev1 "github.com/eslsoft/vocnet/pkg/api/pipeline/v1"
 	"github.com/eslsoft/vocnet/pkg/api/pipeline/v1/pipelinev1connect"
 	"github.com/eslsoft/vocnet/pkg/wordbook"
-	"github.com/samber/lo"
-
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 var _ pipelinev1connect.PipelineServiceHandler = (*PipelineServiceServer)(nil)
@@ -42,7 +43,7 @@ func (s *PipelineServiceServer) ProcessWord(_ context.Context, _ *connect.Reques
 	// ProcessWord is a synchronous pipeline execution. This requires the full Pipeline
 	// orchestrator (not just PipelineService). For now, return unimplemented.
 	// In the future, this could be wired to Pipeline.Run() directly.
-	return nil, connect.NewError(connect.CodeUnimplemented, nil)
+	return nil, connect.NewError(connect.CodeUnimplemented, fmt.Errorf("ProcessWord requires the full pipeline orchestrator"))
 }
 
 func (s *PipelineServiceServer) GetPipelineStatus(ctx context.Context, req *connect.Request[pipelinev1.GetPipelineStatusRequest]) (*connect.Response[pipelinev1.PipelineStatus], error) {
@@ -60,7 +61,7 @@ func (s *PipelineServiceServer) GetPipelineStatus(ctx context.Context, req *conn
 
 func (s *PipelineServiceServer) RetryPhase(_ context.Context, _ *connect.Request[pipelinev1.RetryPhaseRequest]) (*connect.Response[pipelinev1.PipelineStatus], error) {
 	// RetryPhase requires the full Pipeline orchestrator. Return unimplemented for now.
-	return nil, connect.NewError(connect.CodeUnimplemented, nil)
+	return nil, connect.NewError(connect.CodeUnimplemented, fmt.Errorf("RetryPhase requires the full pipeline orchestrator"))
 }
 
 // ---------------------------------------------------------------------------
@@ -154,7 +155,7 @@ func (s *PipelineServiceServer) SubmitJob(ctx context.Context, req *connect.Requ
 		// Resolve wordbook to terms
 		resolvedTerms, resolvedName, resolveErr := resolveWordbook(wbName)
 		if resolveErr != nil {
-			return nil, connect.NewError(connect.CodeInvalidArgument, resolveErr)
+			return nil, connect.NewError(connect.CodeNotFound, resolveErr)
 		}
 		if name == "" {
 			name = resolvedName
@@ -175,6 +176,7 @@ func (s *PipelineServiceServer) SubmitJob(ctx context.Context, req *connect.Requ
 	return connect.NewResponse(mapping.ToPbPipelineJob(job)), nil
 }
 
+//nolint:dupl // GetJob and CancelJob are distinct RPCs with identical structure
 func (s *PipelineServiceServer) GetJob(ctx context.Context, req *connect.Request[pipelinev1.GetJobRequest]) (*connect.Response[pipelinev1.PipelineJob], error) {
 	if req.Msg == nil || req.Msg.GetId() == 0 {
 		return nil, status.Error(codes.InvalidArgument, "job id is required")
@@ -212,6 +214,7 @@ func (s *PipelineServiceServer) ListJobs(ctx context.Context, req *connect.Reque
 	}), nil
 }
 
+//nolint:dupl // CancelJob and GetJob are distinct RPCs with identical structure
 func (s *PipelineServiceServer) CancelJob(ctx context.Context, req *connect.Request[pipelinev1.CancelJobRequest]) (*connect.Response[pipelinev1.PipelineJob], error) {
 	if req.Msg == nil || req.Msg.GetId() == 0 {
 		return nil, status.Error(codes.InvalidArgument, "job id is required")
@@ -267,6 +270,16 @@ func (s *PipelineServiceServer) DownloadDataSource(ctx context.Context, req *con
 // resolveWordbook finds a builtin wordbook by name or ID and returns its terms.
 func resolveWordbook(nameOrID string) ([]string, string, error) {
 	builtins := wordbook.GetBuiltinWordbooks()
+
+	// Try by numeric ID
+	if id, err := strconv.ParseInt(nameOrID, 10, 64); err == nil {
+		for _, wb := range builtins {
+			if wb.Id == id {
+				return wb.Terms, wb.Name, nil
+			}
+		}
+		return nil, "", fmt.Errorf("wordbook with ID %d not found", id)
+	}
 
 	// Try by name (case-insensitive)
 	for _, wb := range builtins {

--- a/internal/adapter/mapping/error.go
+++ b/internal/adapter/mapping/error.go
@@ -39,6 +39,13 @@ func ToPbError(err error) error {
 		return connect.NewError(connect.CodeAlreadyExists, err)
 	case errors.Is(err, entity.ErrBuiltinWordbookLocked):
 		return connect.NewError(connect.CodeFailedPrecondition, err)
+	case errors.Is(err, entity.ErrPipelineJobNotFound),
+		errors.Is(err, entity.ErrSnapshotNotFound),
+		errors.Is(err, entity.ErrLemmaNotFound),
+		errors.Is(err, entity.ErrDataSourceNotFound):
+		return connect.NewError(connect.CodeNotFound, err)
+	case errors.Is(err, entity.ErrJobNotCancellable):
+		return connect.NewError(connect.CodeFailedPrecondition, err)
 	default:
 		return connect.NewError(connect.CodeInternal, err)
 	}

--- a/internal/adapter/mapping/pipeline.go
+++ b/internal/adapter/mapping/pipeline.go
@@ -1,6 +1,8 @@
 package mapping
 
 import (
+	"log/slog"
+
 	"github.com/eslsoft/vocnet/internal/entity"
 	"github.com/eslsoft/vocnet/internal/infrastructure/datasource"
 	pipelinev1 "github.com/eslsoft/vocnet/pkg/api/pipeline/v1"
@@ -25,6 +27,7 @@ func ToPbPipelineJob(j *entity.PipelineJob) *pipelinev1.PipelineJob {
 		Name:         j.Name,
 		Language:     j.Language,
 		Tier:         j.Tier,
+		Term:         j.Term,
 		TotalTerms:   j.TotalTerms,
 		Processed:    j.Processed,
 		Skipped:      j.Skipped,
@@ -166,6 +169,8 @@ func ToPbEvidence(e *entity.RawEvidence) *pipelinev1.Evidence {
 	if e.Content != nil {
 		if s, err := structpb.NewStruct(e.Content); err == nil {
 			pb.Content = s
+		} else {
+			slog.Warn("failed to serialize evidence content to protobuf", "evidence_id", e.ID, "error", err)
 		}
 	}
 

--- a/internal/adapter/mapping/pipeline.go
+++ b/internal/adapter/mapping/pipeline.go
@@ -1,0 +1,188 @@
+package mapping
+
+import (
+	"github.com/eslsoft/vocnet/internal/entity"
+	"github.com/eslsoft/vocnet/internal/infrastructure/datasource"
+	pipelinev1 "github.com/eslsoft/vocnet/pkg/api/pipeline/v1"
+	"github.com/samber/lo"
+	"google.golang.org/protobuf/types/known/structpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// ---------------------------------------------------------------------------
+// Job mapping
+// ---------------------------------------------------------------------------
+
+// ToPbPipelineJob converts an entity PipelineJob to its protobuf representation.
+func ToPbPipelineJob(j *entity.PipelineJob) *pipelinev1.PipelineJob {
+	if j == nil {
+		return nil
+	}
+	pb := &pipelinev1.PipelineJob{
+		Id:           j.ID,
+		JobType:      string(j.JobType),
+		Status:       string(j.Status),
+		Name:         j.Name,
+		Language:     j.Language,
+		Tier:         j.Tier,
+		TotalTerms:   j.TotalTerms,
+		Processed:    j.Processed,
+		Skipped:      j.Skipped,
+		Failed:       j.Failed,
+		ErrorMessage: j.ErrorMessage,
+		CreatedAt:    timestamppb.New(j.CreatedAt),
+	}
+	if j.StartedAt != nil {
+		pb.StartedAt = timestamppb.New(*j.StartedAt)
+	}
+	if j.CompletedAt != nil {
+		pb.CompletedAt = timestamppb.New(*j.CompletedAt)
+	}
+	return pb
+}
+
+// ---------------------------------------------------------------------------
+// Pipeline status mapping
+// ---------------------------------------------------------------------------
+
+// ToPbPipelineStatus converts a lemma and tasks to PipelineStatus.
+func ToPbPipelineStatus(lemma *entity.Lemma, tasks []*entity.PipelineTask) *pipelinev1.PipelineStatus {
+	pb := &pipelinev1.PipelineStatus{
+		LemmaId: lemma.ID,
+		Term:    lemma.Surface,
+		Phases: lo.Map(tasks, func(t *entity.PipelineTask, _ int) *pipelinev1.PhaseStatus {
+			return ToPbPhaseStatus(t)
+		}),
+	}
+	return pb
+}
+
+// ToPbPhaseStatus converts a PipelineTask to its protobuf PhaseStatus.
+func ToPbPhaseStatus(t *entity.PipelineTask) *pipelinev1.PhaseStatus {
+	if t == nil {
+		return nil
+	}
+	ps := &pipelinev1.PhaseStatus{
+		Phase:        t.Phase,
+		Name:         entity.PipelinePhase(t.Phase).Name(),
+		Status:       string(t.Status),
+		Attempts:     t.Attempts,
+		ErrorMessage: t.ErrorMessage,
+	}
+	if t.StartedAt != nil {
+		ps.StartedAt = timestamppb.New(*t.StartedAt)
+	}
+	if t.CompletedAt != nil {
+		ps.CompletedAt = timestamppb.New(*t.CompletedAt)
+	}
+	return ps
+}
+
+// ---------------------------------------------------------------------------
+// Snapshot mapping
+// ---------------------------------------------------------------------------
+
+// ToPbWordSnapshot converts an entity WordSnapshot to its protobuf representation.
+func ToPbWordSnapshot(s *entity.WordSnapshot) *pipelinev1.WordSnapshotResponse {
+	if s == nil {
+		return nil
+	}
+	pb := &pipelinev1.WordSnapshotResponse{
+		Term:        s.Term,
+		Language:    s.Language,
+		WikidataQid: s.WikidataQID,
+		Version:     s.Version,
+		Qscore: &pipelinev1.QualityScore{
+			Overall:      s.QScore,
+			Completeness: s.QScoreCompleteness,
+			Depth:        s.QScoreDepth,
+			Density:      s.QScoreDensity,
+			Validity:     s.QScoreValidity,
+		},
+		SynthesizedAt: timestamppb.New(s.SynthesizedAt),
+	}
+
+	// Map lexemes
+	pb.Lexemes = lo.Map(s.Data.Lexemes, func(l entity.SnapshotLexeme, _ int) *pipelinev1.SnapshotLexeme {
+		return &pipelinev1.SnapshotLexeme{
+			Pos: l.POS,
+			Senses: lo.Map(l.Senses, func(se entity.SnapshotSense, _ int) *pipelinev1.SnapshotSense {
+				return &pipelinev1.SnapshotSense{
+					Language:    se.Language,
+					Gloss:       se.Gloss,
+					Examples:    se.Examples,
+					Provider:    se.Provider,
+					TrustWeight: se.TrustWeight,
+				}
+			}),
+			Forms: lo.Map(l.Forms, func(f entity.SnapshotForm, _ int) *pipelinev1.SnapshotForm {
+				return &pipelinev1.SnapshotForm{
+					Surface:     f.Surface,
+					FormType:    f.FormType,
+					IsIrregular: f.IsIrregular,
+				}
+			}),
+			Phonetics: lo.Map(l.Phonetics, func(p entity.Phonetic, _ int) *pipelinev1.Phonetic {
+				return &pipelinev1.Phonetic{
+					Ipa:     p.IPA,
+					Dialect: p.Dialect,
+				}
+			}),
+		}
+	})
+
+	// Map relations
+	pb.Relations = lo.Map(s.Data.Relations, func(r entity.SnapshotRelation, _ int) *pipelinev1.SnapshotRelation {
+		return &pipelinev1.SnapshotRelation{
+			RelationType: r.RelationType,
+			TargetTerm:   r.TargetTerm,
+			Provider:     r.Provider,
+			Strength:     r.Strength,
+			SenseMapped:  r.SenseMapped,
+		}
+	})
+
+	return pb
+}
+
+// ---------------------------------------------------------------------------
+// Evidence mapping
+// ---------------------------------------------------------------------------
+
+// ToPbEvidence converts an entity RawEvidence to its protobuf representation.
+func ToPbEvidence(e *entity.RawEvidence) *pipelinev1.Evidence {
+	if e == nil {
+		return nil
+	}
+	pb := &pipelinev1.Evidence{
+		Id:            e.ID,
+		Provider:      e.Provider,
+		Phase:         e.Phase,
+		SchemaVersion: e.SchemaVersion,
+		FetchedAt:     timestamppb.New(e.FetchedAt),
+	}
+
+	// Convert map[string]any to protobuf Struct
+	if e.Content != nil {
+		if s, err := structpb.NewStruct(e.Content); err == nil {
+			pb.Content = s
+		}
+	}
+
+	return pb
+}
+
+// ---------------------------------------------------------------------------
+// Data source mapping
+// ---------------------------------------------------------------------------
+
+// ToPbDataSourceStatus converts a datasource.Status to its protobuf representation.
+func ToPbDataSourceStatus(s datasource.Status) *pipelinev1.DataSourceStatus {
+	return &pipelinev1.DataSourceStatus{
+		Name:         s.Name,
+		Path:         s.Path,
+		Available:    s.Available,
+		SizeBytes:    s.Size,
+		ErrorMessage: s.ErrorMsg,
+	}
+}

--- a/internal/adapter/repository/word_snapshot_repo.go
+++ b/internal/adapter/repository/word_snapshot_repo.go
@@ -92,19 +92,14 @@ func (r *wordSnapshotRepository) List(ctx context.Context, query *repository.Lis
 	}
 
 	// Apply ordering
-	orderFunc := entwordsnapshot.ByQscore()
+	dir := orderTerm(query.Desc)
 	switch query.OrderBy {
 	case "synthesized_at":
-		orderFunc = entwordsnapshot.BySynthesizedAt()
+		q = q.Order(entwordsnapshot.BySynthesizedAt(dir), entwordsnapshot.ByID(dir))
 	case "term":
-		orderFunc = entwordsnapshot.ByTerm()
+		q = q.Order(entwordsnapshot.ByTerm(dir), entwordsnapshot.ByID(dir))
 	default:
-		orderFunc = entwordsnapshot.ByQscore()
-	}
-	if query.Desc {
-		q = q.Order(orderFunc, entwordsnapshot.ByID())
-	} else {
-		q = q.Order(orderFunc, entwordsnapshot.ByID())
+		q = q.Order(entwordsnapshot.ByQscore(dir), entwordsnapshot.ByID(dir))
 	}
 
 	// Apply pagination

--- a/internal/adapter/repository/word_snapshot_repo.go
+++ b/internal/adapter/repository/word_snapshot_repo.go
@@ -76,6 +76,60 @@ func (r *wordSnapshotRepository) GetByTerm(ctx context.Context, term string, lan
 	return mapEntWordSnapshot(row), nil
 }
 
+func (r *wordSnapshotRepository) List(ctx context.Context, query *repository.ListSnapshotsQuery) ([]*entity.WordSnapshot, int, error) {
+	q := r.client.WordSnapshot.Query()
+
+	if query.Language != "" {
+		q = q.Where(entwordsnapshot.LanguageEQ(query.Language))
+	}
+	if query.MinQScore > 0 {
+		q = q.Where(entwordsnapshot.QscoreGTE(query.MinQScore))
+	}
+
+	total, err := q.Count(ctx)
+	if err != nil {
+		return nil, 0, fmt.Errorf("count snapshots: %w", err)
+	}
+
+	// Apply ordering
+	orderFunc := entwordsnapshot.ByQscore()
+	switch query.OrderBy {
+	case "synthesized_at":
+		orderFunc = entwordsnapshot.BySynthesizedAt()
+	case "term":
+		orderFunc = entwordsnapshot.ByTerm()
+	default:
+		orderFunc = entwordsnapshot.ByQscore()
+	}
+	if query.Desc {
+		q = q.Order(orderFunc, entwordsnapshot.ByID())
+	} else {
+		q = q.Order(orderFunc, entwordsnapshot.ByID())
+	}
+
+	// Apply pagination
+	pageSize := int(query.PageSize)
+	if pageSize <= 0 {
+		pageSize = 20
+	}
+	pageNo := int(query.PageNo)
+	if pageNo <= 0 {
+		pageNo = 1
+	}
+	q = q.Limit(pageSize).Offset((pageNo - 1) * pageSize)
+
+	rows, err := q.All(ctx)
+	if err != nil {
+		return nil, 0, fmt.Errorf("list snapshots: %w", err)
+	}
+
+	snapshots := make([]*entity.WordSnapshot, len(rows))
+	for i, row := range rows {
+		snapshots[i] = mapEntWordSnapshot(row)
+	}
+	return snapshots, total, nil
+}
+
 func (r *wordSnapshotRepository) getByID(ctx context.Context, id int64) (*entity.WordSnapshot, error) {
 	row, err := r.client.WordSnapshot.Get(ctx, id)
 	if err != nil {

--- a/internal/app/wire.go
+++ b/internal/app/wire.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/eslsoft/vocnet/pkg/api/dict/v1/dictv1connect"
 	"github.com/eslsoft/vocnet/pkg/api/learning/v1/learningv1connect"
+	"github.com/eslsoft/vocnet/pkg/api/pipeline/v1/pipelinev1connect"
 	"github.com/eslsoft/vocnet/pkg/api/wordbook/v1/wordbookv1connect"
 )
 
@@ -28,6 +29,10 @@ var databaseSet = wire.NewSet(
 
 var authSet = wire.NewSet(
 	provideJWTValidator,
+)
+
+var infrastructureSet = wire.NewSet(
+	provideDataSourceManager,
 )
 
 var repositorySet = wire.NewSet(
@@ -62,11 +67,13 @@ var serviceSet = wire.NewSet(
 	adaptergrpc.NewWordbookServiceServer,
 	adaptergrpc.NewReviewPlanServiceServer,
 	adaptergrpc.NewStatsServiceServer,
+	adaptergrpc.NewPipelineServiceServer,
 	wire.Bind(new(learningv1connect.LearningServiceHandler), new(*adaptergrpc.LearningServiceServer)),
 	wire.Bind(new(dictv1connect.DictServiceHandler), new(*adaptergrpc.DictServiceServer)),
 	wire.Bind(new(wordbookv1connect.WordbookServiceHandler), new(*adaptergrpc.WordbookServiceServer)),
 	wire.Bind(new(learningv1connect.ReviewPlanServiceHandler), new(*adaptergrpc.ReviewPlanServiceServer)),
 	wire.Bind(new(learningv1connect.StatsServiceHandler), new(*adaptergrpc.StatsServiceServer)),
+	wire.Bind(new(pipelinev1connect.PipelineServiceHandler), new(*adaptergrpc.PipelineServiceServer)),
 )
 
 var serverSet = wire.NewSet(
@@ -80,6 +87,7 @@ func Initialize() (*Container, func(), error) {
 		configSet,
 		databaseSet,
 		authSet,
+		infrastructureSet,
 		repositorySet,
 		usecaseSet,
 		serviceSet,

--- a/internal/app/wire_gen.go
+++ b/internal/app/wire_gen.go
@@ -16,6 +16,7 @@ import (
 	"github.com/eslsoft/vocnet/internal/usecase/pipeline"
 	"github.com/eslsoft/vocnet/pkg/api/dict/v1/dictv1connect"
 	"github.com/eslsoft/vocnet/pkg/api/learning/v1/learningv1connect"
+	"github.com/eslsoft/vocnet/pkg/api/pipeline/v1/pipelinev1connect"
 	"github.com/eslsoft/vocnet/pkg/api/wordbook/v1/wordbookv1connect"
 	"github.com/google/wire"
 )
@@ -59,15 +60,19 @@ func Initialize() (*Container, func(), error) {
 	reviewPlanServiceServer := connectrpc.NewReviewPlanServiceServer(reviewPlanUsecase)
 	statsUsecase := usecase.NewStatsUsecase(learnedWordRepository, dailyStatsRepository)
 	statsServiceServer := connectrpc.NewStatsServiceServer(statsUsecase)
-	serverServer, err := server.NewServer(configConfig, logger, jwtValidator, dictServiceServer, learningServiceServer, wordbookServiceServer, reviewPlanServiceServer, statsServiceServer)
+	pipelineJobRepository := repository.NewPipelineJobRepository(client)
+	pipelineTaskRepository := repository.NewPipelineTaskRepository(client)
+	wordSnapshotRepository := repository.NewWordSnapshotRepository(client)
+	evidenceRepository := repository.NewEvidenceRepository(client)
+	manager := provideDataSourceManager(configConfig, logger)
+	pipelineService := pipeline.NewPipelineService(pipelineJobRepository, pipelineTaskRepository, wordSnapshotRepository, evidenceRepository, lemmaRepository, manager, logger)
+	pipelineServiceServer := connectrpc.NewPipelineServiceServer(pipelineService)
+	serverServer, err := server.NewServer(configConfig, logger, jwtValidator, dictServiceServer, learningServiceServer, wordbookServiceServer, reviewPlanServiceServer, statsServiceServer, pipelineServiceServer)
 	if err != nil {
 		cleanup2()
 		cleanup()
 		return nil, nil, err
 	}
-	pipelineJobRepository := repository.NewPipelineJobRepository(client)
-	pipelineTaskRepository := repository.NewPipelineTaskRepository(client)
-	pipelineService := pipeline.NewPipelineService(pipelineJobRepository, pipelineTaskRepository, lemmaRepository, logger)
 	container := &Container{
 		Logger:          logger,
 		Config:          configConfig,
@@ -92,10 +97,14 @@ var authSet = wire.NewSet(
 	provideJWTValidator,
 )
 
+var infrastructureSet = wire.NewSet(
+	provideDataSourceManager,
+)
+
 var repositorySet = wire.NewSet(repository.NewLexemeRepository, repository.NewLearnedWordRepository, repository.NewLemmaRepository, repository.NewWordbookRepository, repository.NewReviewPlanRepository, repository.NewDailyStatsRepository, repository.NewEvidenceRepository, repository.NewPipelineTaskRepository, repository.NewSemanticRelationRepository, repository.NewWordSnapshotRepository, repository.NewPipelineJobRepository)
 
 var usecaseSet = wire.NewSet(usecase.NewLexemeUsecase, usecase.NewWordUsecase, usecase.NewLearnedWordUsecase, usecase.NewWordbookUsecase, usecase.NewCardGeneratorFactory, usecase.NewFSRSAlgorithm, usecase.NewReviewPlanUsecase, usecase.NewStatsUsecase, pipeline.NewPipelineService)
 
-var serviceSet = wire.NewSet(connectrpc.NewDictServiceServer, connectrpc.NewLearningServiceServer, connectrpc.NewWordbookServiceServer, connectrpc.NewReviewPlanServiceServer, connectrpc.NewStatsServiceServer, wire.Bind(new(learningv1connect.LearningServiceHandler), new(*connectrpc.LearningServiceServer)), wire.Bind(new(dictv1connect.DictServiceHandler), new(*connectrpc.DictServiceServer)), wire.Bind(new(wordbookv1connect.WordbookServiceHandler), new(*connectrpc.WordbookServiceServer)), wire.Bind(new(learningv1connect.ReviewPlanServiceHandler), new(*connectrpc.ReviewPlanServiceServer)), wire.Bind(new(learningv1connect.StatsServiceHandler), new(*connectrpc.StatsServiceServer)))
+var serviceSet = wire.NewSet(connectrpc.NewDictServiceServer, connectrpc.NewLearningServiceServer, connectrpc.NewWordbookServiceServer, connectrpc.NewReviewPlanServiceServer, connectrpc.NewStatsServiceServer, connectrpc.NewPipelineServiceServer, wire.Bind(new(learningv1connect.LearningServiceHandler), new(*connectrpc.LearningServiceServer)), wire.Bind(new(dictv1connect.DictServiceHandler), new(*connectrpc.DictServiceServer)), wire.Bind(new(wordbookv1connect.WordbookServiceHandler), new(*connectrpc.WordbookServiceServer)), wire.Bind(new(learningv1connect.ReviewPlanServiceHandler), new(*connectrpc.ReviewPlanServiceServer)), wire.Bind(new(learningv1connect.StatsServiceHandler), new(*connectrpc.StatsServiceServer)), wire.Bind(new(pipelinev1connect.PipelineServiceHandler), new(*connectrpc.PipelineServiceServer)))
 
 var serverSet = wire.NewSet(server.NewLogger, server.NewServer)

--- a/internal/app/wire_providers.go
+++ b/internal/app/wire_providers.go
@@ -3,9 +3,11 @@ package app
 import (
 	"context"
 	"fmt"
+	"log/slog"
 
 	"github.com/eslsoft/vocnet/internal/infrastructure/auth"
 	"github.com/eslsoft/vocnet/internal/infrastructure/config"
+	"github.com/eslsoft/vocnet/internal/infrastructure/datasource"
 )
 
 // provideJWTValidator creates a JWT validator from configuration
@@ -33,4 +35,9 @@ func provideJWTValidator(cfg *config.Config) (*auth.JWTValidator, func(), error)
 	}
 
 	return validator, cleanup, nil
+}
+
+// provideDataSourceManager creates a data source manager for the pipeline.
+func provideDataSourceManager(cfg *config.Config, logger *slog.Logger) *datasource.Manager {
+	return datasource.NewManager(cfg, logger, cfg.Pipeline.CacheDir)
 }

--- a/internal/entity/errors.go
+++ b/internal/entity/errors.go
@@ -39,4 +39,8 @@ var (
 	ErrDuplicateReviewPlan   = errors.New("review plan already exists")
 
 	ErrPipelineJobNotFound = errors.New("pipeline job not found")
+	ErrSnapshotNotFound    = errors.New("word snapshot not found")
+	ErrLemmaNotFound       = errors.New("lemma not found")
+	ErrDataSourceNotFound  = errors.New("data source not found")
+	ErrJobNotCancellable   = errors.New("only pending or running jobs can be cancelled")
 )

--- a/internal/infrastructure/server/server.go
+++ b/internal/infrastructure/server/server.go
@@ -153,8 +153,6 @@ func getPublicProcedures() []string {
 		"/pipeline.v1.PipelineService/GetWordSnapshot",
 		"/pipeline.v1.PipelineService/ListWordSnapshots",
 		"/pipeline.v1.PipelineService/GetEvidence",
-		"/pipeline.v1.PipelineService/GetJob",
-		"/pipeline.v1.PipelineService/ListJobs",
 		"/pipeline.v1.PipelineService/ListDataSources",
 	}
 

--- a/internal/infrastructure/server/server.go
+++ b/internal/infrastructure/server/server.go
@@ -20,6 +20,7 @@ import (
 	"github.com/eslsoft/vocnet/internal/infrastructure/usertime"
 	"github.com/eslsoft/vocnet/pkg/api/dict/v1/dictv1connect"
 	"github.com/eslsoft/vocnet/pkg/api/learning/v1/learningv1connect"
+	"github.com/eslsoft/vocnet/pkg/api/pipeline/v1/pipelinev1connect"
 	"github.com/eslsoft/vocnet/pkg/api/wordbook/v1/wordbookv1connect"
 )
 
@@ -33,7 +34,7 @@ type Server struct {
 }
 
 // NewServer creates a new server instance from pre-wired dependencies.
-func NewServer(cfg *config.Config, logger *slog.Logger, jwtValidator *auth.JWTValidator, dictSvc dictv1connect.DictServiceHandler, learningSvc learningv1connect.LearningServiceHandler, wordbookSvc wordbookv1connect.WordbookServiceHandler, reviewPlanSvc learningv1connect.ReviewPlanServiceHandler, statsSvc learningv1connect.StatsServiceHandler) (*Server, error) {
+func NewServer(cfg *config.Config, logger *slog.Logger, jwtValidator *auth.JWTValidator, dictSvc dictv1connect.DictServiceHandler, learningSvc learningv1connect.LearningServiceHandler, wordbookSvc wordbookv1connect.WordbookServiceHandler, reviewPlanSvc learningv1connect.ReviewPlanServiceHandler, statsSvc learningv1connect.StatsServiceHandler, pipelineSvc pipelinev1connect.PipelineServiceHandler) (*Server, error) {
 	// Create access logger interceptor with file support
 	accessLoggerInterceptor, err := LoggerWithConfig(cfg)
 	if err != nil {
@@ -62,6 +63,7 @@ func NewServer(cfg *config.Config, logger *slog.Logger, jwtValidator *auth.JWTVa
 	mux.Handle(wordbookv1connect.NewWordbookServiceHandler(wordbookSvc, interceptors))
 	mux.Handle(learningv1connect.NewReviewPlanServiceHandler(reviewPlanSvc, interceptors))
 	mux.Handle(learningv1connect.NewStatsServiceHandler(statsSvc, interceptors))
+	mux.Handle(pipelinev1connect.NewPipelineServiceHandler(pipelineSvc, interceptors))
 
 	return &Server{
 		config: cfg,
@@ -145,9 +147,20 @@ func getPublicProcedures() []string {
 		"/dict.v1.DictService/ListWords",
 	}
 
+	// Pipeline read-only procedures (public)
+	pipelineProcedures := []string{
+		"/pipeline.v1.PipelineService/GetPipelineStatus",
+		"/pipeline.v1.PipelineService/GetWordSnapshot",
+		"/pipeline.v1.PipelineService/ListWordSnapshots",
+		"/pipeline.v1.PipelineService/GetEvidence",
+		"/pipeline.v1.PipelineService/GetJob",
+		"/pipeline.v1.PipelineService/ListJobs",
+		"/pipeline.v1.PipelineService/ListDataSources",
+	}
+
 	// Note: Some wordbook procedures may optionally support public access
 	// (e.g., GetWordbook can access public wordbooks)
 	// but the auth interceptor will still be called - GetUserIDOrZero handles this
 
-	return dictProcedures
+	return append(dictProcedures, pipelineProcedures...)
 }

--- a/internal/repository/word_snapshot_repository.go
+++ b/internal/repository/word_snapshot_repository.go
@@ -6,9 +6,20 @@ import (
 	"github.com/eslsoft/vocnet/internal/entity"
 )
 
+// ListSnapshotsQuery holds filter/sort/pagination options for listing snapshots.
+type ListSnapshotsQuery struct {
+	Language  string
+	MinQScore float64
+	OrderBy   string // "qscore", "synthesized_at", "term"
+	Desc      bool
+	PageSize  int32
+	PageNo    int32
+}
+
 // WordSnapshotRepository manages materialized word snapshots.
 type WordSnapshotRepository interface {
 	CreateOrUpdate(ctx context.Context, snapshot *entity.WordSnapshot) (*entity.WordSnapshot, error)
 	GetByLemma(ctx context.Context, lemmaID int64) (*entity.WordSnapshot, error)
 	GetByTerm(ctx context.Context, term string, language string) (*entity.WordSnapshot, error)
+	List(ctx context.Context, query *ListSnapshotsQuery) ([]*entity.WordSnapshot, int, error)
 }

--- a/internal/usecase/pipeline/service.go
+++ b/internal/usecase/pipeline/service.go
@@ -8,31 +8,45 @@ import (
 	"time"
 
 	"github.com/eslsoft/vocnet/internal/entity"
+	"github.com/eslsoft/vocnet/internal/infrastructure/datasource"
 	"github.com/eslsoft/vocnet/internal/repository"
 )
 
 // PipelineService is the facade for submitting and querying pipeline jobs.
 type PipelineService struct {
-	jobRepo  repository.PipelineJobRepository
-	taskRepo repository.PipelineTaskRepository
-	lemmaRepo repository.LemmaRepository
-	logger   *slog.Logger
+	jobRepo      repository.PipelineJobRepository
+	taskRepo     repository.PipelineTaskRepository
+	snapshotRepo repository.WordSnapshotRepository
+	evidenceRepo repository.EvidenceRepository
+	lemmaRepo    repository.LemmaRepository
+	dsMgr        *datasource.Manager
+	logger       *slog.Logger
 }
 
 // NewPipelineService creates a new PipelineService.
 func NewPipelineService(
 	jobRepo repository.PipelineJobRepository,
 	taskRepo repository.PipelineTaskRepository,
+	snapshotRepo repository.WordSnapshotRepository,
+	evidenceRepo repository.EvidenceRepository,
 	lemmaRepo repository.LemmaRepository,
+	dsMgr *datasource.Manager,
 	logger *slog.Logger,
 ) *PipelineService {
 	return &PipelineService{
-		jobRepo:   jobRepo,
-		taskRepo:  taskRepo,
-		lemmaRepo: lemmaRepo,
-		logger:    logger,
+		jobRepo:      jobRepo,
+		taskRepo:     taskRepo,
+		snapshotRepo: snapshotRepo,
+		evidenceRepo: evidenceRepo,
+		lemmaRepo:    lemmaRepo,
+		dsMgr:        dsMgr,
+		logger:       logger,
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Job management
+// ---------------------------------------------------------------------------
 
 // SubmitWord creates a single-word pipeline job.
 func (s *PipelineService) SubmitWord(ctx context.Context, term, language string, tier int32) (*entity.PipelineJob, error) {
@@ -99,9 +113,141 @@ func (s *PipelineService) GetJob(ctx context.Context, id int64) (*entity.Pipelin
 }
 
 // ListJobs returns pipeline jobs, optionally filtered by status.
-func (s *PipelineService) ListJobs(ctx context.Context, status *entity.JobStatus) ([]*entity.PipelineJob, error) {
-	return s.jobRepo.List(ctx, status, 50)
+func (s *PipelineService) ListJobs(ctx context.Context, status *entity.JobStatus, limit int) ([]*entity.PipelineJob, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+	return s.jobRepo.List(ctx, status, limit)
 }
+
+// CancelJob cancels a pending or running pipeline job.
+func (s *PipelineService) CancelJob(ctx context.Context, id int64) (*entity.PipelineJob, error) {
+	job, err := s.jobRepo.GetByID(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+
+	if job.Status != entity.JobStatusPending && job.Status != entity.JobStatusRunning {
+		return nil, entity.ErrJobNotCancellable
+	}
+
+	if err := s.jobRepo.UpdateStatus(ctx, id, entity.JobStatusCancelled, "cancelled by user"); err != nil {
+		return nil, err
+	}
+
+	return s.jobRepo.GetByID(ctx, id)
+}
+
+// ---------------------------------------------------------------------------
+// Pipeline status & results
+// ---------------------------------------------------------------------------
+
+// GetPipelineStatus returns the task statuses for a word's pipeline.
+func (s *PipelineService) GetPipelineStatus(ctx context.Context, term, language string) (*entity.Lemma, []*entity.PipelineTask, error) {
+	if language == "" {
+		language = "en"
+	}
+
+	lemma, err := s.lemmaRepo.LookupByForm(ctx, term, entity.Language(language))
+	if err != nil {
+		return nil, nil, entity.ErrLemmaNotFound
+	}
+
+	tasks, err := s.taskRepo.ListByLemma(ctx, lemma.ID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("list tasks: %w", err)
+	}
+
+	return lemma, tasks, nil
+}
+
+// GetWordSnapshot returns the materialized snapshot for a word.
+func (s *PipelineService) GetWordSnapshot(ctx context.Context, term, language string) (*entity.WordSnapshot, error) {
+	if language == "" {
+		language = "en"
+	}
+
+	snapshot, err := s.snapshotRepo.GetByTerm(ctx, term, language)
+	if err != nil {
+		return nil, entity.ErrSnapshotNotFound
+	}
+	return snapshot, nil
+}
+
+// ListWordSnapshots returns a paginated list of snapshots.
+func (s *PipelineService) ListWordSnapshots(ctx context.Context, query *repository.ListSnapshotsQuery) ([]*entity.WordSnapshot, int, error) {
+	return s.snapshotRepo.List(ctx, query)
+}
+
+// GetEvidence returns raw evidence for a word, optionally filtered by phase and provider.
+func (s *PipelineService) GetEvidence(ctx context.Context, term, language string, phase int32, provider string) ([]*entity.RawEvidence, error) {
+	if language == "" {
+		language = "en"
+	}
+
+	lemma, err := s.lemmaRepo.LookupByForm(ctx, term, entity.Language(language))
+	if err != nil {
+		return nil, entity.ErrLemmaNotFound
+	}
+
+	var evidences []*entity.RawEvidence
+	if phase > 0 {
+		evidences, err = s.evidenceRepo.FindByLemmaAndPhase(ctx, lemma.ID, phase)
+	} else {
+		evidences, err = s.evidenceRepo.FindByLemma(ctx, lemma.ID)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("find evidence: %w", err)
+	}
+
+	// Filter by provider if specified
+	if provider != "" {
+		filtered := make([]*entity.RawEvidence, 0, len(evidences))
+		for _, e := range evidences {
+			if e.Provider == provider {
+				filtered = append(filtered, e)
+			}
+		}
+		evidences = filtered
+	}
+
+	return evidences, nil
+}
+
+// ---------------------------------------------------------------------------
+// Data source management
+// ---------------------------------------------------------------------------
+
+// ListDataSources returns the status of all pipeline data sources.
+func (s *PipelineService) ListDataSources(ctx context.Context) ([]datasource.Status, error) {
+	if s.dsMgr == nil {
+		return nil, fmt.Errorf("data source manager not configured")
+	}
+	return s.dsMgr.CheckAll()
+}
+
+// DownloadDataSource downloads a specific or all missing data sources.
+func (s *PipelineService) DownloadDataSource(ctx context.Context, name string) ([]datasource.Status, error) {
+	if s.dsMgr == nil {
+		return nil, fmt.Errorf("data source manager not configured")
+	}
+
+	if name == "" {
+		if err := s.dsMgr.DownloadMissing(ctx); err != nil {
+			return nil, err
+		}
+	} else {
+		if err := s.dsMgr.DownloadSource(ctx, name); err != nil {
+			return nil, err
+		}
+	}
+
+	return s.dsMgr.CheckAll()
+}
+
+// ---------------------------------------------------------------------------
+// Job detail & stage progress
+// ---------------------------------------------------------------------------
 
 // GetJobStageProgress computes stage progress for a single-word job.
 // Returns nil for wordbook jobs (too expensive for list view).

--- a/internal/usecase/pipeline/service.go
+++ b/internal/usecase/pipeline/service.go
@@ -2,6 +2,7 @@ package pipeline
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -150,7 +151,10 @@ func (s *PipelineService) GetPipelineStatus(ctx context.Context, term, language 
 
 	lemma, err := s.lemmaRepo.LookupByForm(ctx, term, entity.Language(language))
 	if err != nil {
-		return nil, nil, entity.ErrLemmaNotFound
+		if errors.Is(err, entity.ErrLemmaNotFound) {
+			return nil, nil, entity.ErrLemmaNotFound
+		}
+		return nil, nil, fmt.Errorf("lookup lemma: %w", err)
 	}
 
 	tasks, err := s.taskRepo.ListByLemma(ctx, lemma.ID)
@@ -169,7 +173,10 @@ func (s *PipelineService) GetWordSnapshot(ctx context.Context, term, language st
 
 	snapshot, err := s.snapshotRepo.GetByTerm(ctx, term, language)
 	if err != nil {
-		return nil, entity.ErrSnapshotNotFound
+		if errors.Is(err, entity.ErrWordNotFound) {
+			return nil, entity.ErrSnapshotNotFound
+		}
+		return nil, fmt.Errorf("get snapshot: %w", err)
 	}
 	return snapshot, nil
 }
@@ -187,7 +194,10 @@ func (s *PipelineService) GetEvidence(ctx context.Context, term, language string
 
 	lemma, err := s.lemmaRepo.LookupByForm(ctx, term, entity.Language(language))
 	if err != nil {
-		return nil, entity.ErrLemmaNotFound
+		if errors.Is(err, entity.ErrLemmaNotFound) {
+			return nil, entity.ErrLemmaNotFound
+		}
+		return nil, fmt.Errorf("lookup lemma: %w", err)
 	}
 
 	var evidences []*entity.RawEvidence

--- a/pkg/api/pipeline/v1/pipeline_service.pb.go
+++ b/pkg/api/pipeline/v1/pipeline_service.pb.go
@@ -1342,6 +1342,679 @@ func (x *Evidence) GetFetchedAt() *timestamppb.Timestamp {
 	return nil
 }
 
+// SubmitJobRequest creates an async pipeline job.
+type SubmitJobRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Exactly one of term, terms, or wordbook_name must be set.
+	Term          string   `protobuf:"bytes,1,opt,name=term,proto3" json:"term,omitempty"`                                     // Single word submission
+	Terms         []string `protobuf:"bytes,2,rep,name=terms,proto3" json:"terms,omitempty"`                                   // Batch term submission
+	WordbookName  string   `protobuf:"bytes,3,opt,name=wordbook_name,json=wordbookName,proto3" json:"wordbook_name,omitempty"` // Built-in wordbook name or ID
+	Language      string   `protobuf:"bytes,4,opt,name=language,proto3" json:"language,omitempty"`                             // Language code (default "en")
+	Tier          int32    `protobuf:"varint,5,opt,name=tier,proto3" json:"tier,omitempty"`                                    // Priority tier (default 2)
+	Name          string   `protobuf:"bytes,6,opt,name=name,proto3" json:"name,omitempty"`                                     // Optional custom job name
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SubmitJobRequest) Reset() {
+	*x = SubmitJobRequest{}
+	mi := &file_pipeline_v1_pipeline_service_proto_msgTypes[19]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SubmitJobRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SubmitJobRequest) ProtoMessage() {}
+
+func (x *SubmitJobRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_pipeline_v1_pipeline_service_proto_msgTypes[19]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SubmitJobRequest.ProtoReflect.Descriptor instead.
+func (*SubmitJobRequest) Descriptor() ([]byte, []int) {
+	return file_pipeline_v1_pipeline_service_proto_rawDescGZIP(), []int{19}
+}
+
+func (x *SubmitJobRequest) GetTerm() string {
+	if x != nil {
+		return x.Term
+	}
+	return ""
+}
+
+func (x *SubmitJobRequest) GetTerms() []string {
+	if x != nil {
+		return x.Terms
+	}
+	return nil
+}
+
+func (x *SubmitJobRequest) GetWordbookName() string {
+	if x != nil {
+		return x.WordbookName
+	}
+	return ""
+}
+
+func (x *SubmitJobRequest) GetLanguage() string {
+	if x != nil {
+		return x.Language
+	}
+	return ""
+}
+
+func (x *SubmitJobRequest) GetTier() int32 {
+	if x != nil {
+		return x.Tier
+	}
+	return 0
+}
+
+func (x *SubmitJobRequest) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+// PipelineJob represents an async pipeline processing job.
+type PipelineJob struct {
+	state    protoimpl.MessageState `protogen:"open.v1"`
+	Id       int64                  `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"`
+	JobType  string                 `protobuf:"bytes,2,opt,name=job_type,json=jobType,proto3" json:"job_type,omitempty"` // SINGLE_WORD, WORDBOOK
+	Status   string                 `protobuf:"bytes,3,opt,name=status,proto3" json:"status,omitempty"`                  // PENDING, RUNNING, COMPLETED, FAILED, CANCELLED
+	Name     string                 `protobuf:"bytes,4,opt,name=name,proto3" json:"name,omitempty"`
+	Language string                 `protobuf:"bytes,5,opt,name=language,proto3" json:"language,omitempty"`
+	Tier     int32                  `protobuf:"varint,6,opt,name=tier,proto3" json:"tier,omitempty"`
+	// Progress tracking
+	TotalTerms    int32                  `protobuf:"varint,7,opt,name=total_terms,json=totalTerms,proto3" json:"total_terms,omitempty"`
+	Processed     int32                  `protobuf:"varint,8,opt,name=processed,proto3" json:"processed,omitempty"`
+	Skipped       int32                  `protobuf:"varint,9,opt,name=skipped,proto3" json:"skipped,omitempty"`
+	Failed        int32                  `protobuf:"varint,10,opt,name=failed,proto3" json:"failed,omitempty"`
+	ErrorMessage  string                 `protobuf:"bytes,11,opt,name=error_message,json=errorMessage,proto3" json:"error_message,omitempty"`
+	StartedAt     *timestamppb.Timestamp `protobuf:"bytes,12,opt,name=started_at,json=startedAt,proto3" json:"started_at,omitempty"`
+	CompletedAt   *timestamppb.Timestamp `protobuf:"bytes,13,opt,name=completed_at,json=completedAt,proto3" json:"completed_at,omitempty"`
+	CreatedAt     *timestamppb.Timestamp `protobuf:"bytes,14,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PipelineJob) Reset() {
+	*x = PipelineJob{}
+	mi := &file_pipeline_v1_pipeline_service_proto_msgTypes[20]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PipelineJob) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PipelineJob) ProtoMessage() {}
+
+func (x *PipelineJob) ProtoReflect() protoreflect.Message {
+	mi := &file_pipeline_v1_pipeline_service_proto_msgTypes[20]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PipelineJob.ProtoReflect.Descriptor instead.
+func (*PipelineJob) Descriptor() ([]byte, []int) {
+	return file_pipeline_v1_pipeline_service_proto_rawDescGZIP(), []int{20}
+}
+
+func (x *PipelineJob) GetId() int64 {
+	if x != nil {
+		return x.Id
+	}
+	return 0
+}
+
+func (x *PipelineJob) GetJobType() string {
+	if x != nil {
+		return x.JobType
+	}
+	return ""
+}
+
+func (x *PipelineJob) GetStatus() string {
+	if x != nil {
+		return x.Status
+	}
+	return ""
+}
+
+func (x *PipelineJob) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *PipelineJob) GetLanguage() string {
+	if x != nil {
+		return x.Language
+	}
+	return ""
+}
+
+func (x *PipelineJob) GetTier() int32 {
+	if x != nil {
+		return x.Tier
+	}
+	return 0
+}
+
+func (x *PipelineJob) GetTotalTerms() int32 {
+	if x != nil {
+		return x.TotalTerms
+	}
+	return 0
+}
+
+func (x *PipelineJob) GetProcessed() int32 {
+	if x != nil {
+		return x.Processed
+	}
+	return 0
+}
+
+func (x *PipelineJob) GetSkipped() int32 {
+	if x != nil {
+		return x.Skipped
+	}
+	return 0
+}
+
+func (x *PipelineJob) GetFailed() int32 {
+	if x != nil {
+		return x.Failed
+	}
+	return 0
+}
+
+func (x *PipelineJob) GetErrorMessage() string {
+	if x != nil {
+		return x.ErrorMessage
+	}
+	return ""
+}
+
+func (x *PipelineJob) GetStartedAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.StartedAt
+	}
+	return nil
+}
+
+func (x *PipelineJob) GetCompletedAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.CompletedAt
+	}
+	return nil
+}
+
+func (x *PipelineJob) GetCreatedAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.CreatedAt
+	}
+	return nil
+}
+
+// GetJobRequest requests details of a specific job.
+type GetJobRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            int64                  `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetJobRequest) Reset() {
+	*x = GetJobRequest{}
+	mi := &file_pipeline_v1_pipeline_service_proto_msgTypes[21]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetJobRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetJobRequest) ProtoMessage() {}
+
+func (x *GetJobRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_pipeline_v1_pipeline_service_proto_msgTypes[21]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetJobRequest.ProtoReflect.Descriptor instead.
+func (*GetJobRequest) Descriptor() ([]byte, []int) {
+	return file_pipeline_v1_pipeline_service_proto_rawDescGZIP(), []int{21}
+}
+
+func (x *GetJobRequest) GetId() int64 {
+	if x != nil {
+		return x.Id
+	}
+	return 0
+}
+
+// ListJobsRequest requests a filtered list of pipeline jobs.
+type ListJobsRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Status        string                 `protobuf:"bytes,1,opt,name=status,proto3" json:"status,omitempty"` // Filter by status (empty = all)
+	Limit         int32                  `protobuf:"varint,2,opt,name=limit,proto3" json:"limit,omitempty"`  // Max results (default 50)
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListJobsRequest) Reset() {
+	*x = ListJobsRequest{}
+	mi := &file_pipeline_v1_pipeline_service_proto_msgTypes[22]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListJobsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListJobsRequest) ProtoMessage() {}
+
+func (x *ListJobsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_pipeline_v1_pipeline_service_proto_msgTypes[22]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListJobsRequest.ProtoReflect.Descriptor instead.
+func (*ListJobsRequest) Descriptor() ([]byte, []int) {
+	return file_pipeline_v1_pipeline_service_proto_rawDescGZIP(), []int{22}
+}
+
+func (x *ListJobsRequest) GetStatus() string {
+	if x != nil {
+		return x.Status
+	}
+	return ""
+}
+
+func (x *ListJobsRequest) GetLimit() int32 {
+	if x != nil {
+		return x.Limit
+	}
+	return 0
+}
+
+// ListJobsResponse contains a list of pipeline jobs.
+type ListJobsResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Jobs          []*PipelineJob         `protobuf:"bytes,1,rep,name=jobs,proto3" json:"jobs,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListJobsResponse) Reset() {
+	*x = ListJobsResponse{}
+	mi := &file_pipeline_v1_pipeline_service_proto_msgTypes[23]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListJobsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListJobsResponse) ProtoMessage() {}
+
+func (x *ListJobsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_pipeline_v1_pipeline_service_proto_msgTypes[23]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListJobsResponse.ProtoReflect.Descriptor instead.
+func (*ListJobsResponse) Descriptor() ([]byte, []int) {
+	return file_pipeline_v1_pipeline_service_proto_rawDescGZIP(), []int{23}
+}
+
+func (x *ListJobsResponse) GetJobs() []*PipelineJob {
+	if x != nil {
+		return x.Jobs
+	}
+	return nil
+}
+
+// CancelJobRequest cancels a pipeline job.
+type CancelJobRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            int64                  `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CancelJobRequest) Reset() {
+	*x = CancelJobRequest{}
+	mi := &file_pipeline_v1_pipeline_service_proto_msgTypes[24]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CancelJobRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CancelJobRequest) ProtoMessage() {}
+
+func (x *CancelJobRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_pipeline_v1_pipeline_service_proto_msgTypes[24]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CancelJobRequest.ProtoReflect.Descriptor instead.
+func (*CancelJobRequest) Descriptor() ([]byte, []int) {
+	return file_pipeline_v1_pipeline_service_proto_rawDescGZIP(), []int{24}
+}
+
+func (x *CancelJobRequest) GetId() int64 {
+	if x != nil {
+		return x.Id
+	}
+	return 0
+}
+
+// ListDataSourcesRequest requests status of all data sources.
+type ListDataSourcesRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListDataSourcesRequest) Reset() {
+	*x = ListDataSourcesRequest{}
+	mi := &file_pipeline_v1_pipeline_service_proto_msgTypes[25]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListDataSourcesRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListDataSourcesRequest) ProtoMessage() {}
+
+func (x *ListDataSourcesRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_pipeline_v1_pipeline_service_proto_msgTypes[25]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListDataSourcesRequest.ProtoReflect.Descriptor instead.
+func (*ListDataSourcesRequest) Descriptor() ([]byte, []int) {
+	return file_pipeline_v1_pipeline_service_proto_rawDescGZIP(), []int{25}
+}
+
+// ListDataSourcesResponse contains data source statuses.
+type ListDataSourcesResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Sources       []*DataSourceStatus    `protobuf:"bytes,1,rep,name=sources,proto3" json:"sources,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListDataSourcesResponse) Reset() {
+	*x = ListDataSourcesResponse{}
+	mi := &file_pipeline_v1_pipeline_service_proto_msgTypes[26]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListDataSourcesResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListDataSourcesResponse) ProtoMessage() {}
+
+func (x *ListDataSourcesResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_pipeline_v1_pipeline_service_proto_msgTypes[26]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListDataSourcesResponse.ProtoReflect.Descriptor instead.
+func (*ListDataSourcesResponse) Descriptor() ([]byte, []int) {
+	return file_pipeline_v1_pipeline_service_proto_rawDescGZIP(), []int{26}
+}
+
+func (x *ListDataSourcesResponse) GetSources() []*DataSourceStatus {
+	if x != nil {
+		return x.Sources
+	}
+	return nil
+}
+
+// DataSourceStatus represents the status of a pipeline data source.
+type DataSourceStatus struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	Path          string                 `protobuf:"bytes,2,opt,name=path,proto3" json:"path,omitempty"`
+	Available     bool                   `protobuf:"varint,3,opt,name=available,proto3" json:"available,omitempty"`
+	SizeBytes     int64                  `protobuf:"varint,4,opt,name=size_bytes,json=sizeBytes,proto3" json:"size_bytes,omitempty"`
+	ErrorMessage  string                 `protobuf:"bytes,5,opt,name=error_message,json=errorMessage,proto3" json:"error_message,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DataSourceStatus) Reset() {
+	*x = DataSourceStatus{}
+	mi := &file_pipeline_v1_pipeline_service_proto_msgTypes[27]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DataSourceStatus) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DataSourceStatus) ProtoMessage() {}
+
+func (x *DataSourceStatus) ProtoReflect() protoreflect.Message {
+	mi := &file_pipeline_v1_pipeline_service_proto_msgTypes[27]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DataSourceStatus.ProtoReflect.Descriptor instead.
+func (*DataSourceStatus) Descriptor() ([]byte, []int) {
+	return file_pipeline_v1_pipeline_service_proto_rawDescGZIP(), []int{27}
+}
+
+func (x *DataSourceStatus) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *DataSourceStatus) GetPath() string {
+	if x != nil {
+		return x.Path
+	}
+	return ""
+}
+
+func (x *DataSourceStatus) GetAvailable() bool {
+	if x != nil {
+		return x.Available
+	}
+	return false
+}
+
+func (x *DataSourceStatus) GetSizeBytes() int64 {
+	if x != nil {
+		return x.SizeBytes
+	}
+	return 0
+}
+
+func (x *DataSourceStatus) GetErrorMessage() string {
+	if x != nil {
+		return x.ErrorMessage
+	}
+	return ""
+}
+
+// DownloadDataSourceRequest requests download of a specific data source.
+type DownloadDataSourceRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"` // Source name: conceptnet, ecdict, wordnet, moby (empty = all missing)
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DownloadDataSourceRequest) Reset() {
+	*x = DownloadDataSourceRequest{}
+	mi := &file_pipeline_v1_pipeline_service_proto_msgTypes[28]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DownloadDataSourceRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DownloadDataSourceRequest) ProtoMessage() {}
+
+func (x *DownloadDataSourceRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_pipeline_v1_pipeline_service_proto_msgTypes[28]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DownloadDataSourceRequest.ProtoReflect.Descriptor instead.
+func (*DownloadDataSourceRequest) Descriptor() ([]byte, []int) {
+	return file_pipeline_v1_pipeline_service_proto_rawDescGZIP(), []int{28}
+}
+
+func (x *DownloadDataSourceRequest) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+// DownloadDataSourceResponse confirms download completion.
+type DownloadDataSourceResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Sources       []*DataSourceStatus    `protobuf:"bytes,1,rep,name=sources,proto3" json:"sources,omitempty"` // Updated statuses after download
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DownloadDataSourceResponse) Reset() {
+	*x = DownloadDataSourceResponse{}
+	mi := &file_pipeline_v1_pipeline_service_proto_msgTypes[29]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DownloadDataSourceResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DownloadDataSourceResponse) ProtoMessage() {}
+
+func (x *DownloadDataSourceResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_pipeline_v1_pipeline_service_proto_msgTypes[29]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DownloadDataSourceResponse.ProtoReflect.Descriptor instead.
+func (*DownloadDataSourceResponse) Descriptor() ([]byte, []int) {
+	return file_pipeline_v1_pipeline_service_proto_rawDescGZIP(), []int{29}
+}
+
+func (x *DownloadDataSourceResponse) GetSources() []*DataSourceStatus {
+	if x != nil {
+		return x.Sources
+	}
+	return nil
+}
+
 var File_pipeline_v1_pipeline_service_proto protoreflect.FileDescriptor
 
 const file_pipeline_v1_pipeline_service_proto_rawDesc = "" +
@@ -1446,7 +2119,56 @@ const file_pipeline_v1_pipeline_service_proto_rawDesc = "" +
 	"\acontent\x18\x04 \x01(\v2\x17.google.protobuf.StructR\acontent\x12%\n" +
 	"\x0eschema_version\x18\x05 \x01(\tR\rschemaVersion\x129\n" +
 	"\n" +
-	"fetched_at\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\tfetchedAt2\x98\x04\n" +
+	"fetched_at\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\tfetchedAt\"\xa5\x01\n" +
+	"\x10SubmitJobRequest\x12\x12\n" +
+	"\x04term\x18\x01 \x01(\tR\x04term\x12\x14\n" +
+	"\x05terms\x18\x02 \x03(\tR\x05terms\x12#\n" +
+	"\rwordbook_name\x18\x03 \x01(\tR\fwordbookName\x12\x1a\n" +
+	"\blanguage\x18\x04 \x01(\tR\blanguage\x12\x12\n" +
+	"\x04tier\x18\x05 \x01(\x05R\x04tier\x12\x12\n" +
+	"\x04name\x18\x06 \x01(\tR\x04name\"\xdf\x03\n" +
+	"\vPipelineJob\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\x03R\x02id\x12\x19\n" +
+	"\bjob_type\x18\x02 \x01(\tR\ajobType\x12\x16\n" +
+	"\x06status\x18\x03 \x01(\tR\x06status\x12\x12\n" +
+	"\x04name\x18\x04 \x01(\tR\x04name\x12\x1a\n" +
+	"\blanguage\x18\x05 \x01(\tR\blanguage\x12\x12\n" +
+	"\x04tier\x18\x06 \x01(\x05R\x04tier\x12\x1f\n" +
+	"\vtotal_terms\x18\a \x01(\x05R\n" +
+	"totalTerms\x12\x1c\n" +
+	"\tprocessed\x18\b \x01(\x05R\tprocessed\x12\x18\n" +
+	"\askipped\x18\t \x01(\x05R\askipped\x12\x16\n" +
+	"\x06failed\x18\n" +
+	" \x01(\x05R\x06failed\x12#\n" +
+	"\rerror_message\x18\v \x01(\tR\ferrorMessage\x129\n" +
+	"\n" +
+	"started_at\x18\f \x01(\v2\x1a.google.protobuf.TimestampR\tstartedAt\x12=\n" +
+	"\fcompleted_at\x18\r \x01(\v2\x1a.google.protobuf.TimestampR\vcompletedAt\x129\n" +
+	"\n" +
+	"created_at\x18\x0e \x01(\v2\x1a.google.protobuf.TimestampR\tcreatedAt\"\x1f\n" +
+	"\rGetJobRequest\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\x03R\x02id\"?\n" +
+	"\x0fListJobsRequest\x12\x16\n" +
+	"\x06status\x18\x01 \x01(\tR\x06status\x12\x14\n" +
+	"\x05limit\x18\x02 \x01(\x05R\x05limit\"@\n" +
+	"\x10ListJobsResponse\x12,\n" +
+	"\x04jobs\x18\x01 \x03(\v2\x18.pipeline.v1.PipelineJobR\x04jobs\"\"\n" +
+	"\x10CancelJobRequest\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\x03R\x02id\"\x18\n" +
+	"\x16ListDataSourcesRequest\"R\n" +
+	"\x17ListDataSourcesResponse\x127\n" +
+	"\asources\x18\x01 \x03(\v2\x1d.pipeline.v1.DataSourceStatusR\asources\"\x9c\x01\n" +
+	"\x10DataSourceStatus\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12\x12\n" +
+	"\x04path\x18\x02 \x01(\tR\x04path\x12\x1c\n" +
+	"\tavailable\x18\x03 \x01(\bR\tavailable\x12\x1d\n" +
+	"\n" +
+	"size_bytes\x18\x04 \x01(\x03R\tsizeBytes\x12#\n" +
+	"\rerror_message\x18\x05 \x01(\tR\ferrorMessage\"/\n" +
+	"\x19DownloadDataSourceRequest\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\"U\n" +
+	"\x1aDownloadDataSourceResponse\x127\n" +
+	"\asources\x18\x01 \x03(\v2\x1d.pipeline.v1.DataSourceStatusR\asources2\xf2\a\n" +
 	"\x0fPipelineService\x12P\n" +
 	"\vProcessWord\x12\x1f.pipeline.v1.ProcessWordRequest\x1a .pipeline.v1.ProcessWordResponse\x12W\n" +
 	"\x11GetPipelineStatus\x12%.pipeline.v1.GetPipelineStatusRequest\x1a\x1b.pipeline.v1.PipelineStatus\x12I\n" +
@@ -1454,7 +2176,13 @@ const file_pipeline_v1_pipeline_service_proto_rawDesc = "" +
 	"RetryPhase\x12\x1e.pipeline.v1.RetryPhaseRequest\x1a\x1b.pipeline.v1.PipelineStatus\x12Y\n" +
 	"\x0fGetWordSnapshot\x12#.pipeline.v1.GetWordSnapshotRequest\x1a!.pipeline.v1.WordSnapshotResponse\x12b\n" +
 	"\x11ListWordSnapshots\x12%.pipeline.v1.ListWordSnapshotsRequest\x1a&.pipeline.v1.ListWordSnapshotsResponse\x12P\n" +
-	"\vGetEvidence\x12\x1f.pipeline.v1.GetEvidenceRequest\x1a .pipeline.v1.GetEvidenceResponseB\xae\x01\n" +
+	"\vGetEvidence\x12\x1f.pipeline.v1.GetEvidenceRequest\x1a .pipeline.v1.GetEvidenceResponse\x12D\n" +
+	"\tSubmitJob\x12\x1d.pipeline.v1.SubmitJobRequest\x1a\x18.pipeline.v1.PipelineJob\x12>\n" +
+	"\x06GetJob\x12\x1a.pipeline.v1.GetJobRequest\x1a\x18.pipeline.v1.PipelineJob\x12G\n" +
+	"\bListJobs\x12\x1c.pipeline.v1.ListJobsRequest\x1a\x1d.pipeline.v1.ListJobsResponse\x12D\n" +
+	"\tCancelJob\x12\x1d.pipeline.v1.CancelJobRequest\x1a\x18.pipeline.v1.PipelineJob\x12\\\n" +
+	"\x0fListDataSources\x12#.pipeline.v1.ListDataSourcesRequest\x1a$.pipeline.v1.ListDataSourcesResponse\x12e\n" +
+	"\x12DownloadDataSource\x12&.pipeline.v1.DownloadDataSourceRequest\x1a'.pipeline.v1.DownloadDataSourceResponseB\xae\x01\n" +
 	"\x0fcom.pipeline.v1B\x14PipelineServiceProtoP\x01Z8github.com/eslsoft/vocnet/pkg/api/pipeline/v1;pipelinev1\xa2\x02\x03PXX\xaa\x02\vPipeline.V1\xca\x02\vPipeline\\V1\xe2\x02\x17Pipeline\\V1\\GPBMetadata\xea\x02\fPipeline::V1b\x06proto3"
 
 var (
@@ -1469,64 +2197,93 @@ func file_pipeline_v1_pipeline_service_proto_rawDescGZIP() []byte {
 	return file_pipeline_v1_pipeline_service_proto_rawDescData
 }
 
-var file_pipeline_v1_pipeline_service_proto_msgTypes = make([]protoimpl.MessageInfo, 19)
+var file_pipeline_v1_pipeline_service_proto_msgTypes = make([]protoimpl.MessageInfo, 30)
 var file_pipeline_v1_pipeline_service_proto_goTypes = []any{
-	(*ProcessWordRequest)(nil),        // 0: pipeline.v1.ProcessWordRequest
-	(*ProcessWordResponse)(nil),       // 1: pipeline.v1.ProcessWordResponse
-	(*GetPipelineStatusRequest)(nil),  // 2: pipeline.v1.GetPipelineStatusRequest
-	(*PipelineStatus)(nil),            // 3: pipeline.v1.PipelineStatus
-	(*PhaseStatus)(nil),               // 4: pipeline.v1.PhaseStatus
-	(*RetryPhaseRequest)(nil),         // 5: pipeline.v1.RetryPhaseRequest
-	(*GetWordSnapshotRequest)(nil),    // 6: pipeline.v1.GetWordSnapshotRequest
-	(*WordSnapshotResponse)(nil),      // 7: pipeline.v1.WordSnapshotResponse
-	(*SnapshotLexeme)(nil),            // 8: pipeline.v1.SnapshotLexeme
-	(*SnapshotSense)(nil),             // 9: pipeline.v1.SnapshotSense
-	(*SnapshotForm)(nil),              // 10: pipeline.v1.SnapshotForm
-	(*Phonetic)(nil),                  // 11: pipeline.v1.Phonetic
-	(*SnapshotRelation)(nil),          // 12: pipeline.v1.SnapshotRelation
-	(*QualityScore)(nil),              // 13: pipeline.v1.QualityScore
-	(*ListWordSnapshotsRequest)(nil),  // 14: pipeline.v1.ListWordSnapshotsRequest
-	(*ListWordSnapshotsResponse)(nil), // 15: pipeline.v1.ListWordSnapshotsResponse
-	(*GetEvidenceRequest)(nil),        // 16: pipeline.v1.GetEvidenceRequest
-	(*GetEvidenceResponse)(nil),       // 17: pipeline.v1.GetEvidenceResponse
-	(*Evidence)(nil),                  // 18: pipeline.v1.Evidence
-	(*timestamppb.Timestamp)(nil),     // 19: google.protobuf.Timestamp
-	(*structpb.Struct)(nil),           // 20: google.protobuf.Struct
+	(*ProcessWordRequest)(nil),         // 0: pipeline.v1.ProcessWordRequest
+	(*ProcessWordResponse)(nil),        // 1: pipeline.v1.ProcessWordResponse
+	(*GetPipelineStatusRequest)(nil),   // 2: pipeline.v1.GetPipelineStatusRequest
+	(*PipelineStatus)(nil),             // 3: pipeline.v1.PipelineStatus
+	(*PhaseStatus)(nil),                // 4: pipeline.v1.PhaseStatus
+	(*RetryPhaseRequest)(nil),          // 5: pipeline.v1.RetryPhaseRequest
+	(*GetWordSnapshotRequest)(nil),     // 6: pipeline.v1.GetWordSnapshotRequest
+	(*WordSnapshotResponse)(nil),       // 7: pipeline.v1.WordSnapshotResponse
+	(*SnapshotLexeme)(nil),             // 8: pipeline.v1.SnapshotLexeme
+	(*SnapshotSense)(nil),              // 9: pipeline.v1.SnapshotSense
+	(*SnapshotForm)(nil),               // 10: pipeline.v1.SnapshotForm
+	(*Phonetic)(nil),                   // 11: pipeline.v1.Phonetic
+	(*SnapshotRelation)(nil),           // 12: pipeline.v1.SnapshotRelation
+	(*QualityScore)(nil),               // 13: pipeline.v1.QualityScore
+	(*ListWordSnapshotsRequest)(nil),   // 14: pipeline.v1.ListWordSnapshotsRequest
+	(*ListWordSnapshotsResponse)(nil),  // 15: pipeline.v1.ListWordSnapshotsResponse
+	(*GetEvidenceRequest)(nil),         // 16: pipeline.v1.GetEvidenceRequest
+	(*GetEvidenceResponse)(nil),        // 17: pipeline.v1.GetEvidenceResponse
+	(*Evidence)(nil),                   // 18: pipeline.v1.Evidence
+	(*SubmitJobRequest)(nil),           // 19: pipeline.v1.SubmitJobRequest
+	(*PipelineJob)(nil),                // 20: pipeline.v1.PipelineJob
+	(*GetJobRequest)(nil),              // 21: pipeline.v1.GetJobRequest
+	(*ListJobsRequest)(nil),            // 22: pipeline.v1.ListJobsRequest
+	(*ListJobsResponse)(nil),           // 23: pipeline.v1.ListJobsResponse
+	(*CancelJobRequest)(nil),           // 24: pipeline.v1.CancelJobRequest
+	(*ListDataSourcesRequest)(nil),     // 25: pipeline.v1.ListDataSourcesRequest
+	(*ListDataSourcesResponse)(nil),    // 26: pipeline.v1.ListDataSourcesResponse
+	(*DataSourceStatus)(nil),           // 27: pipeline.v1.DataSourceStatus
+	(*DownloadDataSourceRequest)(nil),  // 28: pipeline.v1.DownloadDataSourceRequest
+	(*DownloadDataSourceResponse)(nil), // 29: pipeline.v1.DownloadDataSourceResponse
+	(*timestamppb.Timestamp)(nil),      // 30: google.protobuf.Timestamp
+	(*structpb.Struct)(nil),            // 31: google.protobuf.Struct
 }
 var file_pipeline_v1_pipeline_service_proto_depIdxs = []int32{
 	3,  // 0: pipeline.v1.ProcessWordResponse.status:type_name -> pipeline.v1.PipelineStatus
 	7,  // 1: pipeline.v1.ProcessWordResponse.snapshot:type_name -> pipeline.v1.WordSnapshotResponse
 	4,  // 2: pipeline.v1.PipelineStatus.phases:type_name -> pipeline.v1.PhaseStatus
-	19, // 3: pipeline.v1.PhaseStatus.started_at:type_name -> google.protobuf.Timestamp
-	19, // 4: pipeline.v1.PhaseStatus.completed_at:type_name -> google.protobuf.Timestamp
+	30, // 3: pipeline.v1.PhaseStatus.started_at:type_name -> google.protobuf.Timestamp
+	30, // 4: pipeline.v1.PhaseStatus.completed_at:type_name -> google.protobuf.Timestamp
 	8,  // 5: pipeline.v1.WordSnapshotResponse.lexemes:type_name -> pipeline.v1.SnapshotLexeme
 	12, // 6: pipeline.v1.WordSnapshotResponse.relations:type_name -> pipeline.v1.SnapshotRelation
 	13, // 7: pipeline.v1.WordSnapshotResponse.qscore:type_name -> pipeline.v1.QualityScore
-	19, // 8: pipeline.v1.WordSnapshotResponse.synthesized_at:type_name -> google.protobuf.Timestamp
+	30, // 8: pipeline.v1.WordSnapshotResponse.synthesized_at:type_name -> google.protobuf.Timestamp
 	9,  // 9: pipeline.v1.SnapshotLexeme.senses:type_name -> pipeline.v1.SnapshotSense
 	10, // 10: pipeline.v1.SnapshotLexeme.forms:type_name -> pipeline.v1.SnapshotForm
 	11, // 11: pipeline.v1.SnapshotLexeme.phonetics:type_name -> pipeline.v1.Phonetic
 	7,  // 12: pipeline.v1.ListWordSnapshotsResponse.snapshots:type_name -> pipeline.v1.WordSnapshotResponse
 	18, // 13: pipeline.v1.GetEvidenceResponse.evidences:type_name -> pipeline.v1.Evidence
-	20, // 14: pipeline.v1.Evidence.content:type_name -> google.protobuf.Struct
-	19, // 15: pipeline.v1.Evidence.fetched_at:type_name -> google.protobuf.Timestamp
-	0,  // 16: pipeline.v1.PipelineService.ProcessWord:input_type -> pipeline.v1.ProcessWordRequest
-	2,  // 17: pipeline.v1.PipelineService.GetPipelineStatus:input_type -> pipeline.v1.GetPipelineStatusRequest
-	5,  // 18: pipeline.v1.PipelineService.RetryPhase:input_type -> pipeline.v1.RetryPhaseRequest
-	6,  // 19: pipeline.v1.PipelineService.GetWordSnapshot:input_type -> pipeline.v1.GetWordSnapshotRequest
-	14, // 20: pipeline.v1.PipelineService.ListWordSnapshots:input_type -> pipeline.v1.ListWordSnapshotsRequest
-	16, // 21: pipeline.v1.PipelineService.GetEvidence:input_type -> pipeline.v1.GetEvidenceRequest
-	1,  // 22: pipeline.v1.PipelineService.ProcessWord:output_type -> pipeline.v1.ProcessWordResponse
-	3,  // 23: pipeline.v1.PipelineService.GetPipelineStatus:output_type -> pipeline.v1.PipelineStatus
-	3,  // 24: pipeline.v1.PipelineService.RetryPhase:output_type -> pipeline.v1.PipelineStatus
-	7,  // 25: pipeline.v1.PipelineService.GetWordSnapshot:output_type -> pipeline.v1.WordSnapshotResponse
-	15, // 26: pipeline.v1.PipelineService.ListWordSnapshots:output_type -> pipeline.v1.ListWordSnapshotsResponse
-	17, // 27: pipeline.v1.PipelineService.GetEvidence:output_type -> pipeline.v1.GetEvidenceResponse
-	22, // [22:28] is the sub-list for method output_type
-	16, // [16:22] is the sub-list for method input_type
-	16, // [16:16] is the sub-list for extension type_name
-	16, // [16:16] is the sub-list for extension extendee
-	0,  // [0:16] is the sub-list for field type_name
+	31, // 14: pipeline.v1.Evidence.content:type_name -> google.protobuf.Struct
+	30, // 15: pipeline.v1.Evidence.fetched_at:type_name -> google.protobuf.Timestamp
+	30, // 16: pipeline.v1.PipelineJob.started_at:type_name -> google.protobuf.Timestamp
+	30, // 17: pipeline.v1.PipelineJob.completed_at:type_name -> google.protobuf.Timestamp
+	30, // 18: pipeline.v1.PipelineJob.created_at:type_name -> google.protobuf.Timestamp
+	20, // 19: pipeline.v1.ListJobsResponse.jobs:type_name -> pipeline.v1.PipelineJob
+	27, // 20: pipeline.v1.ListDataSourcesResponse.sources:type_name -> pipeline.v1.DataSourceStatus
+	27, // 21: pipeline.v1.DownloadDataSourceResponse.sources:type_name -> pipeline.v1.DataSourceStatus
+	0,  // 22: pipeline.v1.PipelineService.ProcessWord:input_type -> pipeline.v1.ProcessWordRequest
+	2,  // 23: pipeline.v1.PipelineService.GetPipelineStatus:input_type -> pipeline.v1.GetPipelineStatusRequest
+	5,  // 24: pipeline.v1.PipelineService.RetryPhase:input_type -> pipeline.v1.RetryPhaseRequest
+	6,  // 25: pipeline.v1.PipelineService.GetWordSnapshot:input_type -> pipeline.v1.GetWordSnapshotRequest
+	14, // 26: pipeline.v1.PipelineService.ListWordSnapshots:input_type -> pipeline.v1.ListWordSnapshotsRequest
+	16, // 27: pipeline.v1.PipelineService.GetEvidence:input_type -> pipeline.v1.GetEvidenceRequest
+	19, // 28: pipeline.v1.PipelineService.SubmitJob:input_type -> pipeline.v1.SubmitJobRequest
+	21, // 29: pipeline.v1.PipelineService.GetJob:input_type -> pipeline.v1.GetJobRequest
+	22, // 30: pipeline.v1.PipelineService.ListJobs:input_type -> pipeline.v1.ListJobsRequest
+	24, // 31: pipeline.v1.PipelineService.CancelJob:input_type -> pipeline.v1.CancelJobRequest
+	25, // 32: pipeline.v1.PipelineService.ListDataSources:input_type -> pipeline.v1.ListDataSourcesRequest
+	28, // 33: pipeline.v1.PipelineService.DownloadDataSource:input_type -> pipeline.v1.DownloadDataSourceRequest
+	1,  // 34: pipeline.v1.PipelineService.ProcessWord:output_type -> pipeline.v1.ProcessWordResponse
+	3,  // 35: pipeline.v1.PipelineService.GetPipelineStatus:output_type -> pipeline.v1.PipelineStatus
+	3,  // 36: pipeline.v1.PipelineService.RetryPhase:output_type -> pipeline.v1.PipelineStatus
+	7,  // 37: pipeline.v1.PipelineService.GetWordSnapshot:output_type -> pipeline.v1.WordSnapshotResponse
+	15, // 38: pipeline.v1.PipelineService.ListWordSnapshots:output_type -> pipeline.v1.ListWordSnapshotsResponse
+	17, // 39: pipeline.v1.PipelineService.GetEvidence:output_type -> pipeline.v1.GetEvidenceResponse
+	20, // 40: pipeline.v1.PipelineService.SubmitJob:output_type -> pipeline.v1.PipelineJob
+	20, // 41: pipeline.v1.PipelineService.GetJob:output_type -> pipeline.v1.PipelineJob
+	23, // 42: pipeline.v1.PipelineService.ListJobs:output_type -> pipeline.v1.ListJobsResponse
+	20, // 43: pipeline.v1.PipelineService.CancelJob:output_type -> pipeline.v1.PipelineJob
+	26, // 44: pipeline.v1.PipelineService.ListDataSources:output_type -> pipeline.v1.ListDataSourcesResponse
+	29, // 45: pipeline.v1.PipelineService.DownloadDataSource:output_type -> pipeline.v1.DownloadDataSourceResponse
+	34, // [34:46] is the sub-list for method output_type
+	22, // [22:34] is the sub-list for method input_type
+	22, // [22:22] is the sub-list for extension type_name
+	22, // [22:22] is the sub-list for extension extendee
+	0,  // [0:22] is the sub-list for field type_name
 }
 
 func init() { file_pipeline_v1_pipeline_service_proto_init() }
@@ -1540,7 +2297,7 @@ func file_pipeline_v1_pipeline_service_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_pipeline_v1_pipeline_service_proto_rawDesc), len(file_pipeline_v1_pipeline_service_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   19,
+			NumMessages:   30,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/pkg/api/pipeline/v1/pipeline_service.pb.go
+++ b/pkg/api/pipeline/v1/pipeline_service.pb.go
@@ -1446,6 +1446,7 @@ type PipelineJob struct {
 	StartedAt     *timestamppb.Timestamp `protobuf:"bytes,12,opt,name=started_at,json=startedAt,proto3" json:"started_at,omitempty"`
 	CompletedAt   *timestamppb.Timestamp `protobuf:"bytes,13,opt,name=completed_at,json=completedAt,proto3" json:"completed_at,omitempty"`
 	CreatedAt     *timestamppb.Timestamp `protobuf:"bytes,14,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`
+	Term          string                 `protobuf:"bytes,15,opt,name=term,proto3" json:"term,omitempty"` // Target term (for SINGLE_WORD jobs)
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1576,6 +1577,13 @@ func (x *PipelineJob) GetCreatedAt() *timestamppb.Timestamp {
 		return x.CreatedAt
 	}
 	return nil
+}
+
+func (x *PipelineJob) GetTerm() string {
+	if x != nil {
+		return x.Term
+	}
+	return ""
 }
 
 // GetJobRequest requests details of a specific job.
@@ -2126,7 +2134,7 @@ const file_pipeline_v1_pipeline_service_proto_rawDesc = "" +
 	"\rwordbook_name\x18\x03 \x01(\tR\fwordbookName\x12\x1a\n" +
 	"\blanguage\x18\x04 \x01(\tR\blanguage\x12\x12\n" +
 	"\x04tier\x18\x05 \x01(\x05R\x04tier\x12\x12\n" +
-	"\x04name\x18\x06 \x01(\tR\x04name\"\xdf\x03\n" +
+	"\x04name\x18\x06 \x01(\tR\x04name\"\xf3\x03\n" +
 	"\vPipelineJob\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\x03R\x02id\x12\x19\n" +
 	"\bjob_type\x18\x02 \x01(\tR\ajobType\x12\x16\n" +
@@ -2145,7 +2153,8 @@ const file_pipeline_v1_pipeline_service_proto_rawDesc = "" +
 	"started_at\x18\f \x01(\v2\x1a.google.protobuf.TimestampR\tstartedAt\x12=\n" +
 	"\fcompleted_at\x18\r \x01(\v2\x1a.google.protobuf.TimestampR\vcompletedAt\x129\n" +
 	"\n" +
-	"created_at\x18\x0e \x01(\v2\x1a.google.protobuf.TimestampR\tcreatedAt\"\x1f\n" +
+	"created_at\x18\x0e \x01(\v2\x1a.google.protobuf.TimestampR\tcreatedAt\x12\x12\n" +
+	"\x04term\x18\x0f \x01(\tR\x04term\"\x1f\n" +
 	"\rGetJobRequest\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\x03R\x02id\"?\n" +
 	"\x0fListJobsRequest\x12\x16\n" +

--- a/pkg/api/pipeline/v1/pipeline_service.pb.validate.go
+++ b/pkg/api/pipeline/v1/pipeline_service.pb.validate.go
@@ -2571,3 +2571,1351 @@ var _ interface {
 	Cause() error
 	ErrorName() string
 } = EvidenceValidationError{}
+
+// Validate checks the field values on SubmitJobRequest with the rules defined
+// in the proto definition for this message. If any rules are violated, the
+// first error encountered is returned, or nil if there are no violations.
+func (m *SubmitJobRequest) Validate() error {
+	return m.validate(false)
+}
+
+// ValidateAll checks the field values on SubmitJobRequest with the rules
+// defined in the proto definition for this message. If any rules are
+// violated, the result is a list of violation errors wrapped in
+// SubmitJobRequestMultiError, or nil if none found.
+func (m *SubmitJobRequest) ValidateAll() error {
+	return m.validate(true)
+}
+
+func (m *SubmitJobRequest) validate(all bool) error {
+	if m == nil {
+		return nil
+	}
+
+	var errors []error
+
+	// no validation rules for Term
+
+	// no validation rules for WordbookName
+
+	// no validation rules for Language
+
+	// no validation rules for Tier
+
+	// no validation rules for Name
+
+	if len(errors) > 0 {
+		return SubmitJobRequestMultiError(errors)
+	}
+
+	return nil
+}
+
+// SubmitJobRequestMultiError is an error wrapping multiple validation errors
+// returned by SubmitJobRequest.ValidateAll() if the designated constraints
+// aren't met.
+type SubmitJobRequestMultiError []error
+
+// Error returns a concatenation of all the error messages it wraps.
+func (m SubmitJobRequestMultiError) Error() string {
+	msgs := make([]string, 0, len(m))
+	for _, err := range m {
+		msgs = append(msgs, err.Error())
+	}
+	return strings.Join(msgs, "; ")
+}
+
+// AllErrors returns a list of validation violation errors.
+func (m SubmitJobRequestMultiError) AllErrors() []error { return m }
+
+// SubmitJobRequestValidationError is the validation error returned by
+// SubmitJobRequest.Validate if the designated constraints aren't met.
+type SubmitJobRequestValidationError struct {
+	field  string
+	reason string
+	cause  error
+	key    bool
+}
+
+// Field function returns field value.
+func (e SubmitJobRequestValidationError) Field() string { return e.field }
+
+// Reason function returns reason value.
+func (e SubmitJobRequestValidationError) Reason() string { return e.reason }
+
+// Cause function returns cause value.
+func (e SubmitJobRequestValidationError) Cause() error { return e.cause }
+
+// Key function returns key value.
+func (e SubmitJobRequestValidationError) Key() bool { return e.key }
+
+// ErrorName returns error name.
+func (e SubmitJobRequestValidationError) ErrorName() string { return "SubmitJobRequestValidationError" }
+
+// Error satisfies the builtin error interface
+func (e SubmitJobRequestValidationError) Error() string {
+	cause := ""
+	if e.cause != nil {
+		cause = fmt.Sprintf(" | caused by: %v", e.cause)
+	}
+
+	key := ""
+	if e.key {
+		key = "key for "
+	}
+
+	return fmt.Sprintf(
+		"invalid %sSubmitJobRequest.%s: %s%s",
+		key,
+		e.field,
+		e.reason,
+		cause)
+}
+
+var _ error = SubmitJobRequestValidationError{}
+
+var _ interface {
+	Field() string
+	Reason() string
+	Key() bool
+	Cause() error
+	ErrorName() string
+} = SubmitJobRequestValidationError{}
+
+// Validate checks the field values on PipelineJob with the rules defined in
+// the proto definition for this message. If any rules are violated, the first
+// error encountered is returned, or nil if there are no violations.
+func (m *PipelineJob) Validate() error {
+	return m.validate(false)
+}
+
+// ValidateAll checks the field values on PipelineJob with the rules defined in
+// the proto definition for this message. If any rules are violated, the
+// result is a list of violation errors wrapped in PipelineJobMultiError, or
+// nil if none found.
+func (m *PipelineJob) ValidateAll() error {
+	return m.validate(true)
+}
+
+func (m *PipelineJob) validate(all bool) error {
+	if m == nil {
+		return nil
+	}
+
+	var errors []error
+
+	// no validation rules for Id
+
+	// no validation rules for JobType
+
+	// no validation rules for Status
+
+	// no validation rules for Name
+
+	// no validation rules for Language
+
+	// no validation rules for Tier
+
+	// no validation rules for TotalTerms
+
+	// no validation rules for Processed
+
+	// no validation rules for Skipped
+
+	// no validation rules for Failed
+
+	// no validation rules for ErrorMessage
+
+	if all {
+		switch v := interface{}(m.GetStartedAt()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, PipelineJobValidationError{
+					field:  "StartedAt",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, PipelineJobValidationError{
+					field:  "StartedAt",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetStartedAt()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return PipelineJobValidationError{
+				field:  "StartedAt",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
+	}
+
+	if all {
+		switch v := interface{}(m.GetCompletedAt()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, PipelineJobValidationError{
+					field:  "CompletedAt",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, PipelineJobValidationError{
+					field:  "CompletedAt",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetCompletedAt()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return PipelineJobValidationError{
+				field:  "CompletedAt",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
+	}
+
+	if all {
+		switch v := interface{}(m.GetCreatedAt()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, PipelineJobValidationError{
+					field:  "CreatedAt",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, PipelineJobValidationError{
+					field:  "CreatedAt",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetCreatedAt()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return PipelineJobValidationError{
+				field:  "CreatedAt",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
+	}
+
+	if len(errors) > 0 {
+		return PipelineJobMultiError(errors)
+	}
+
+	return nil
+}
+
+// PipelineJobMultiError is an error wrapping multiple validation errors
+// returned by PipelineJob.ValidateAll() if the designated constraints aren't met.
+type PipelineJobMultiError []error
+
+// Error returns a concatenation of all the error messages it wraps.
+func (m PipelineJobMultiError) Error() string {
+	msgs := make([]string, 0, len(m))
+	for _, err := range m {
+		msgs = append(msgs, err.Error())
+	}
+	return strings.Join(msgs, "; ")
+}
+
+// AllErrors returns a list of validation violation errors.
+func (m PipelineJobMultiError) AllErrors() []error { return m }
+
+// PipelineJobValidationError is the validation error returned by
+// PipelineJob.Validate if the designated constraints aren't met.
+type PipelineJobValidationError struct {
+	field  string
+	reason string
+	cause  error
+	key    bool
+}
+
+// Field function returns field value.
+func (e PipelineJobValidationError) Field() string { return e.field }
+
+// Reason function returns reason value.
+func (e PipelineJobValidationError) Reason() string { return e.reason }
+
+// Cause function returns cause value.
+func (e PipelineJobValidationError) Cause() error { return e.cause }
+
+// Key function returns key value.
+func (e PipelineJobValidationError) Key() bool { return e.key }
+
+// ErrorName returns error name.
+func (e PipelineJobValidationError) ErrorName() string { return "PipelineJobValidationError" }
+
+// Error satisfies the builtin error interface
+func (e PipelineJobValidationError) Error() string {
+	cause := ""
+	if e.cause != nil {
+		cause = fmt.Sprintf(" | caused by: %v", e.cause)
+	}
+
+	key := ""
+	if e.key {
+		key = "key for "
+	}
+
+	return fmt.Sprintf(
+		"invalid %sPipelineJob.%s: %s%s",
+		key,
+		e.field,
+		e.reason,
+		cause)
+}
+
+var _ error = PipelineJobValidationError{}
+
+var _ interface {
+	Field() string
+	Reason() string
+	Key() bool
+	Cause() error
+	ErrorName() string
+} = PipelineJobValidationError{}
+
+// Validate checks the field values on GetJobRequest with the rules defined in
+// the proto definition for this message. If any rules are violated, the first
+// error encountered is returned, or nil if there are no violations.
+func (m *GetJobRequest) Validate() error {
+	return m.validate(false)
+}
+
+// ValidateAll checks the field values on GetJobRequest with the rules defined
+// in the proto definition for this message. If any rules are violated, the
+// result is a list of violation errors wrapped in GetJobRequestMultiError, or
+// nil if none found.
+func (m *GetJobRequest) ValidateAll() error {
+	return m.validate(true)
+}
+
+func (m *GetJobRequest) validate(all bool) error {
+	if m == nil {
+		return nil
+	}
+
+	var errors []error
+
+	// no validation rules for Id
+
+	if len(errors) > 0 {
+		return GetJobRequestMultiError(errors)
+	}
+
+	return nil
+}
+
+// GetJobRequestMultiError is an error wrapping multiple validation errors
+// returned by GetJobRequest.ValidateAll() if the designated constraints
+// aren't met.
+type GetJobRequestMultiError []error
+
+// Error returns a concatenation of all the error messages it wraps.
+func (m GetJobRequestMultiError) Error() string {
+	msgs := make([]string, 0, len(m))
+	for _, err := range m {
+		msgs = append(msgs, err.Error())
+	}
+	return strings.Join(msgs, "; ")
+}
+
+// AllErrors returns a list of validation violation errors.
+func (m GetJobRequestMultiError) AllErrors() []error { return m }
+
+// GetJobRequestValidationError is the validation error returned by
+// GetJobRequest.Validate if the designated constraints aren't met.
+type GetJobRequestValidationError struct {
+	field  string
+	reason string
+	cause  error
+	key    bool
+}
+
+// Field function returns field value.
+func (e GetJobRequestValidationError) Field() string { return e.field }
+
+// Reason function returns reason value.
+func (e GetJobRequestValidationError) Reason() string { return e.reason }
+
+// Cause function returns cause value.
+func (e GetJobRequestValidationError) Cause() error { return e.cause }
+
+// Key function returns key value.
+func (e GetJobRequestValidationError) Key() bool { return e.key }
+
+// ErrorName returns error name.
+func (e GetJobRequestValidationError) ErrorName() string { return "GetJobRequestValidationError" }
+
+// Error satisfies the builtin error interface
+func (e GetJobRequestValidationError) Error() string {
+	cause := ""
+	if e.cause != nil {
+		cause = fmt.Sprintf(" | caused by: %v", e.cause)
+	}
+
+	key := ""
+	if e.key {
+		key = "key for "
+	}
+
+	return fmt.Sprintf(
+		"invalid %sGetJobRequest.%s: %s%s",
+		key,
+		e.field,
+		e.reason,
+		cause)
+}
+
+var _ error = GetJobRequestValidationError{}
+
+var _ interface {
+	Field() string
+	Reason() string
+	Key() bool
+	Cause() error
+	ErrorName() string
+} = GetJobRequestValidationError{}
+
+// Validate checks the field values on ListJobsRequest with the rules defined
+// in the proto definition for this message. If any rules are violated, the
+// first error encountered is returned, or nil if there are no violations.
+func (m *ListJobsRequest) Validate() error {
+	return m.validate(false)
+}
+
+// ValidateAll checks the field values on ListJobsRequest with the rules
+// defined in the proto definition for this message. If any rules are
+// violated, the result is a list of violation errors wrapped in
+// ListJobsRequestMultiError, or nil if none found.
+func (m *ListJobsRequest) ValidateAll() error {
+	return m.validate(true)
+}
+
+func (m *ListJobsRequest) validate(all bool) error {
+	if m == nil {
+		return nil
+	}
+
+	var errors []error
+
+	// no validation rules for Status
+
+	// no validation rules for Limit
+
+	if len(errors) > 0 {
+		return ListJobsRequestMultiError(errors)
+	}
+
+	return nil
+}
+
+// ListJobsRequestMultiError is an error wrapping multiple validation errors
+// returned by ListJobsRequest.ValidateAll() if the designated constraints
+// aren't met.
+type ListJobsRequestMultiError []error
+
+// Error returns a concatenation of all the error messages it wraps.
+func (m ListJobsRequestMultiError) Error() string {
+	msgs := make([]string, 0, len(m))
+	for _, err := range m {
+		msgs = append(msgs, err.Error())
+	}
+	return strings.Join(msgs, "; ")
+}
+
+// AllErrors returns a list of validation violation errors.
+func (m ListJobsRequestMultiError) AllErrors() []error { return m }
+
+// ListJobsRequestValidationError is the validation error returned by
+// ListJobsRequest.Validate if the designated constraints aren't met.
+type ListJobsRequestValidationError struct {
+	field  string
+	reason string
+	cause  error
+	key    bool
+}
+
+// Field function returns field value.
+func (e ListJobsRequestValidationError) Field() string { return e.field }
+
+// Reason function returns reason value.
+func (e ListJobsRequestValidationError) Reason() string { return e.reason }
+
+// Cause function returns cause value.
+func (e ListJobsRequestValidationError) Cause() error { return e.cause }
+
+// Key function returns key value.
+func (e ListJobsRequestValidationError) Key() bool { return e.key }
+
+// ErrorName returns error name.
+func (e ListJobsRequestValidationError) ErrorName() string { return "ListJobsRequestValidationError" }
+
+// Error satisfies the builtin error interface
+func (e ListJobsRequestValidationError) Error() string {
+	cause := ""
+	if e.cause != nil {
+		cause = fmt.Sprintf(" | caused by: %v", e.cause)
+	}
+
+	key := ""
+	if e.key {
+		key = "key for "
+	}
+
+	return fmt.Sprintf(
+		"invalid %sListJobsRequest.%s: %s%s",
+		key,
+		e.field,
+		e.reason,
+		cause)
+}
+
+var _ error = ListJobsRequestValidationError{}
+
+var _ interface {
+	Field() string
+	Reason() string
+	Key() bool
+	Cause() error
+	ErrorName() string
+} = ListJobsRequestValidationError{}
+
+// Validate checks the field values on ListJobsResponse with the rules defined
+// in the proto definition for this message. If any rules are violated, the
+// first error encountered is returned, or nil if there are no violations.
+func (m *ListJobsResponse) Validate() error {
+	return m.validate(false)
+}
+
+// ValidateAll checks the field values on ListJobsResponse with the rules
+// defined in the proto definition for this message. If any rules are
+// violated, the result is a list of violation errors wrapped in
+// ListJobsResponseMultiError, or nil if none found.
+func (m *ListJobsResponse) ValidateAll() error {
+	return m.validate(true)
+}
+
+func (m *ListJobsResponse) validate(all bool) error {
+	if m == nil {
+		return nil
+	}
+
+	var errors []error
+
+	for idx, item := range m.GetJobs() {
+		_, _ = idx, item
+
+		if all {
+			switch v := interface{}(item).(type) {
+			case interface{ ValidateAll() error }:
+				if err := v.ValidateAll(); err != nil {
+					errors = append(errors, ListJobsResponseValidationError{
+						field:  fmt.Sprintf("Jobs[%v]", idx),
+						reason: "embedded message failed validation",
+						cause:  err,
+					})
+				}
+			case interface{ Validate() error }:
+				if err := v.Validate(); err != nil {
+					errors = append(errors, ListJobsResponseValidationError{
+						field:  fmt.Sprintf("Jobs[%v]", idx),
+						reason: "embedded message failed validation",
+						cause:  err,
+					})
+				}
+			}
+		} else if v, ok := interface{}(item).(interface{ Validate() error }); ok {
+			if err := v.Validate(); err != nil {
+				return ListJobsResponseValidationError{
+					field:  fmt.Sprintf("Jobs[%v]", idx),
+					reason: "embedded message failed validation",
+					cause:  err,
+				}
+			}
+		}
+
+	}
+
+	if len(errors) > 0 {
+		return ListJobsResponseMultiError(errors)
+	}
+
+	return nil
+}
+
+// ListJobsResponseMultiError is an error wrapping multiple validation errors
+// returned by ListJobsResponse.ValidateAll() if the designated constraints
+// aren't met.
+type ListJobsResponseMultiError []error
+
+// Error returns a concatenation of all the error messages it wraps.
+func (m ListJobsResponseMultiError) Error() string {
+	msgs := make([]string, 0, len(m))
+	for _, err := range m {
+		msgs = append(msgs, err.Error())
+	}
+	return strings.Join(msgs, "; ")
+}
+
+// AllErrors returns a list of validation violation errors.
+func (m ListJobsResponseMultiError) AllErrors() []error { return m }
+
+// ListJobsResponseValidationError is the validation error returned by
+// ListJobsResponse.Validate if the designated constraints aren't met.
+type ListJobsResponseValidationError struct {
+	field  string
+	reason string
+	cause  error
+	key    bool
+}
+
+// Field function returns field value.
+func (e ListJobsResponseValidationError) Field() string { return e.field }
+
+// Reason function returns reason value.
+func (e ListJobsResponseValidationError) Reason() string { return e.reason }
+
+// Cause function returns cause value.
+func (e ListJobsResponseValidationError) Cause() error { return e.cause }
+
+// Key function returns key value.
+func (e ListJobsResponseValidationError) Key() bool { return e.key }
+
+// ErrorName returns error name.
+func (e ListJobsResponseValidationError) ErrorName() string { return "ListJobsResponseValidationError" }
+
+// Error satisfies the builtin error interface
+func (e ListJobsResponseValidationError) Error() string {
+	cause := ""
+	if e.cause != nil {
+		cause = fmt.Sprintf(" | caused by: %v", e.cause)
+	}
+
+	key := ""
+	if e.key {
+		key = "key for "
+	}
+
+	return fmt.Sprintf(
+		"invalid %sListJobsResponse.%s: %s%s",
+		key,
+		e.field,
+		e.reason,
+		cause)
+}
+
+var _ error = ListJobsResponseValidationError{}
+
+var _ interface {
+	Field() string
+	Reason() string
+	Key() bool
+	Cause() error
+	ErrorName() string
+} = ListJobsResponseValidationError{}
+
+// Validate checks the field values on CancelJobRequest with the rules defined
+// in the proto definition for this message. If any rules are violated, the
+// first error encountered is returned, or nil if there are no violations.
+func (m *CancelJobRequest) Validate() error {
+	return m.validate(false)
+}
+
+// ValidateAll checks the field values on CancelJobRequest with the rules
+// defined in the proto definition for this message. If any rules are
+// violated, the result is a list of violation errors wrapped in
+// CancelJobRequestMultiError, or nil if none found.
+func (m *CancelJobRequest) ValidateAll() error {
+	return m.validate(true)
+}
+
+func (m *CancelJobRequest) validate(all bool) error {
+	if m == nil {
+		return nil
+	}
+
+	var errors []error
+
+	// no validation rules for Id
+
+	if len(errors) > 0 {
+		return CancelJobRequestMultiError(errors)
+	}
+
+	return nil
+}
+
+// CancelJobRequestMultiError is an error wrapping multiple validation errors
+// returned by CancelJobRequest.ValidateAll() if the designated constraints
+// aren't met.
+type CancelJobRequestMultiError []error
+
+// Error returns a concatenation of all the error messages it wraps.
+func (m CancelJobRequestMultiError) Error() string {
+	msgs := make([]string, 0, len(m))
+	for _, err := range m {
+		msgs = append(msgs, err.Error())
+	}
+	return strings.Join(msgs, "; ")
+}
+
+// AllErrors returns a list of validation violation errors.
+func (m CancelJobRequestMultiError) AllErrors() []error { return m }
+
+// CancelJobRequestValidationError is the validation error returned by
+// CancelJobRequest.Validate if the designated constraints aren't met.
+type CancelJobRequestValidationError struct {
+	field  string
+	reason string
+	cause  error
+	key    bool
+}
+
+// Field function returns field value.
+func (e CancelJobRequestValidationError) Field() string { return e.field }
+
+// Reason function returns reason value.
+func (e CancelJobRequestValidationError) Reason() string { return e.reason }
+
+// Cause function returns cause value.
+func (e CancelJobRequestValidationError) Cause() error { return e.cause }
+
+// Key function returns key value.
+func (e CancelJobRequestValidationError) Key() bool { return e.key }
+
+// ErrorName returns error name.
+func (e CancelJobRequestValidationError) ErrorName() string { return "CancelJobRequestValidationError" }
+
+// Error satisfies the builtin error interface
+func (e CancelJobRequestValidationError) Error() string {
+	cause := ""
+	if e.cause != nil {
+		cause = fmt.Sprintf(" | caused by: %v", e.cause)
+	}
+
+	key := ""
+	if e.key {
+		key = "key for "
+	}
+
+	return fmt.Sprintf(
+		"invalid %sCancelJobRequest.%s: %s%s",
+		key,
+		e.field,
+		e.reason,
+		cause)
+}
+
+var _ error = CancelJobRequestValidationError{}
+
+var _ interface {
+	Field() string
+	Reason() string
+	Key() bool
+	Cause() error
+	ErrorName() string
+} = CancelJobRequestValidationError{}
+
+// Validate checks the field values on ListDataSourcesRequest with the rules
+// defined in the proto definition for this message. If any rules are
+// violated, the first error encountered is returned, or nil if there are no violations.
+func (m *ListDataSourcesRequest) Validate() error {
+	return m.validate(false)
+}
+
+// ValidateAll checks the field values on ListDataSourcesRequest with the rules
+// defined in the proto definition for this message. If any rules are
+// violated, the result is a list of violation errors wrapped in
+// ListDataSourcesRequestMultiError, or nil if none found.
+func (m *ListDataSourcesRequest) ValidateAll() error {
+	return m.validate(true)
+}
+
+func (m *ListDataSourcesRequest) validate(all bool) error {
+	if m == nil {
+		return nil
+	}
+
+	var errors []error
+
+	if len(errors) > 0 {
+		return ListDataSourcesRequestMultiError(errors)
+	}
+
+	return nil
+}
+
+// ListDataSourcesRequestMultiError is an error wrapping multiple validation
+// errors returned by ListDataSourcesRequest.ValidateAll() if the designated
+// constraints aren't met.
+type ListDataSourcesRequestMultiError []error
+
+// Error returns a concatenation of all the error messages it wraps.
+func (m ListDataSourcesRequestMultiError) Error() string {
+	msgs := make([]string, 0, len(m))
+	for _, err := range m {
+		msgs = append(msgs, err.Error())
+	}
+	return strings.Join(msgs, "; ")
+}
+
+// AllErrors returns a list of validation violation errors.
+func (m ListDataSourcesRequestMultiError) AllErrors() []error { return m }
+
+// ListDataSourcesRequestValidationError is the validation error returned by
+// ListDataSourcesRequest.Validate if the designated constraints aren't met.
+type ListDataSourcesRequestValidationError struct {
+	field  string
+	reason string
+	cause  error
+	key    bool
+}
+
+// Field function returns field value.
+func (e ListDataSourcesRequestValidationError) Field() string { return e.field }
+
+// Reason function returns reason value.
+func (e ListDataSourcesRequestValidationError) Reason() string { return e.reason }
+
+// Cause function returns cause value.
+func (e ListDataSourcesRequestValidationError) Cause() error { return e.cause }
+
+// Key function returns key value.
+func (e ListDataSourcesRequestValidationError) Key() bool { return e.key }
+
+// ErrorName returns error name.
+func (e ListDataSourcesRequestValidationError) ErrorName() string {
+	return "ListDataSourcesRequestValidationError"
+}
+
+// Error satisfies the builtin error interface
+func (e ListDataSourcesRequestValidationError) Error() string {
+	cause := ""
+	if e.cause != nil {
+		cause = fmt.Sprintf(" | caused by: %v", e.cause)
+	}
+
+	key := ""
+	if e.key {
+		key = "key for "
+	}
+
+	return fmt.Sprintf(
+		"invalid %sListDataSourcesRequest.%s: %s%s",
+		key,
+		e.field,
+		e.reason,
+		cause)
+}
+
+var _ error = ListDataSourcesRequestValidationError{}
+
+var _ interface {
+	Field() string
+	Reason() string
+	Key() bool
+	Cause() error
+	ErrorName() string
+} = ListDataSourcesRequestValidationError{}
+
+// Validate checks the field values on ListDataSourcesResponse with the rules
+// defined in the proto definition for this message. If any rules are
+// violated, the first error encountered is returned, or nil if there are no violations.
+func (m *ListDataSourcesResponse) Validate() error {
+	return m.validate(false)
+}
+
+// ValidateAll checks the field values on ListDataSourcesResponse with the
+// rules defined in the proto definition for this message. If any rules are
+// violated, the result is a list of violation errors wrapped in
+// ListDataSourcesResponseMultiError, or nil if none found.
+func (m *ListDataSourcesResponse) ValidateAll() error {
+	return m.validate(true)
+}
+
+func (m *ListDataSourcesResponse) validate(all bool) error {
+	if m == nil {
+		return nil
+	}
+
+	var errors []error
+
+	for idx, item := range m.GetSources() {
+		_, _ = idx, item
+
+		if all {
+			switch v := interface{}(item).(type) {
+			case interface{ ValidateAll() error }:
+				if err := v.ValidateAll(); err != nil {
+					errors = append(errors, ListDataSourcesResponseValidationError{
+						field:  fmt.Sprintf("Sources[%v]", idx),
+						reason: "embedded message failed validation",
+						cause:  err,
+					})
+				}
+			case interface{ Validate() error }:
+				if err := v.Validate(); err != nil {
+					errors = append(errors, ListDataSourcesResponseValidationError{
+						field:  fmt.Sprintf("Sources[%v]", idx),
+						reason: "embedded message failed validation",
+						cause:  err,
+					})
+				}
+			}
+		} else if v, ok := interface{}(item).(interface{ Validate() error }); ok {
+			if err := v.Validate(); err != nil {
+				return ListDataSourcesResponseValidationError{
+					field:  fmt.Sprintf("Sources[%v]", idx),
+					reason: "embedded message failed validation",
+					cause:  err,
+				}
+			}
+		}
+
+	}
+
+	if len(errors) > 0 {
+		return ListDataSourcesResponseMultiError(errors)
+	}
+
+	return nil
+}
+
+// ListDataSourcesResponseMultiError is an error wrapping multiple validation
+// errors returned by ListDataSourcesResponse.ValidateAll() if the designated
+// constraints aren't met.
+type ListDataSourcesResponseMultiError []error
+
+// Error returns a concatenation of all the error messages it wraps.
+func (m ListDataSourcesResponseMultiError) Error() string {
+	msgs := make([]string, 0, len(m))
+	for _, err := range m {
+		msgs = append(msgs, err.Error())
+	}
+	return strings.Join(msgs, "; ")
+}
+
+// AllErrors returns a list of validation violation errors.
+func (m ListDataSourcesResponseMultiError) AllErrors() []error { return m }
+
+// ListDataSourcesResponseValidationError is the validation error returned by
+// ListDataSourcesResponse.Validate if the designated constraints aren't met.
+type ListDataSourcesResponseValidationError struct {
+	field  string
+	reason string
+	cause  error
+	key    bool
+}
+
+// Field function returns field value.
+func (e ListDataSourcesResponseValidationError) Field() string { return e.field }
+
+// Reason function returns reason value.
+func (e ListDataSourcesResponseValidationError) Reason() string { return e.reason }
+
+// Cause function returns cause value.
+func (e ListDataSourcesResponseValidationError) Cause() error { return e.cause }
+
+// Key function returns key value.
+func (e ListDataSourcesResponseValidationError) Key() bool { return e.key }
+
+// ErrorName returns error name.
+func (e ListDataSourcesResponseValidationError) ErrorName() string {
+	return "ListDataSourcesResponseValidationError"
+}
+
+// Error satisfies the builtin error interface
+func (e ListDataSourcesResponseValidationError) Error() string {
+	cause := ""
+	if e.cause != nil {
+		cause = fmt.Sprintf(" | caused by: %v", e.cause)
+	}
+
+	key := ""
+	if e.key {
+		key = "key for "
+	}
+
+	return fmt.Sprintf(
+		"invalid %sListDataSourcesResponse.%s: %s%s",
+		key,
+		e.field,
+		e.reason,
+		cause)
+}
+
+var _ error = ListDataSourcesResponseValidationError{}
+
+var _ interface {
+	Field() string
+	Reason() string
+	Key() bool
+	Cause() error
+	ErrorName() string
+} = ListDataSourcesResponseValidationError{}
+
+// Validate checks the field values on DataSourceStatus with the rules defined
+// in the proto definition for this message. If any rules are violated, the
+// first error encountered is returned, or nil if there are no violations.
+func (m *DataSourceStatus) Validate() error {
+	return m.validate(false)
+}
+
+// ValidateAll checks the field values on DataSourceStatus with the rules
+// defined in the proto definition for this message. If any rules are
+// violated, the result is a list of violation errors wrapped in
+// DataSourceStatusMultiError, or nil if none found.
+func (m *DataSourceStatus) ValidateAll() error {
+	return m.validate(true)
+}
+
+func (m *DataSourceStatus) validate(all bool) error {
+	if m == nil {
+		return nil
+	}
+
+	var errors []error
+
+	// no validation rules for Name
+
+	// no validation rules for Path
+
+	// no validation rules for Available
+
+	// no validation rules for SizeBytes
+
+	// no validation rules for ErrorMessage
+
+	if len(errors) > 0 {
+		return DataSourceStatusMultiError(errors)
+	}
+
+	return nil
+}
+
+// DataSourceStatusMultiError is an error wrapping multiple validation errors
+// returned by DataSourceStatus.ValidateAll() if the designated constraints
+// aren't met.
+type DataSourceStatusMultiError []error
+
+// Error returns a concatenation of all the error messages it wraps.
+func (m DataSourceStatusMultiError) Error() string {
+	msgs := make([]string, 0, len(m))
+	for _, err := range m {
+		msgs = append(msgs, err.Error())
+	}
+	return strings.Join(msgs, "; ")
+}
+
+// AllErrors returns a list of validation violation errors.
+func (m DataSourceStatusMultiError) AllErrors() []error { return m }
+
+// DataSourceStatusValidationError is the validation error returned by
+// DataSourceStatus.Validate if the designated constraints aren't met.
+type DataSourceStatusValidationError struct {
+	field  string
+	reason string
+	cause  error
+	key    bool
+}
+
+// Field function returns field value.
+func (e DataSourceStatusValidationError) Field() string { return e.field }
+
+// Reason function returns reason value.
+func (e DataSourceStatusValidationError) Reason() string { return e.reason }
+
+// Cause function returns cause value.
+func (e DataSourceStatusValidationError) Cause() error { return e.cause }
+
+// Key function returns key value.
+func (e DataSourceStatusValidationError) Key() bool { return e.key }
+
+// ErrorName returns error name.
+func (e DataSourceStatusValidationError) ErrorName() string { return "DataSourceStatusValidationError" }
+
+// Error satisfies the builtin error interface
+func (e DataSourceStatusValidationError) Error() string {
+	cause := ""
+	if e.cause != nil {
+		cause = fmt.Sprintf(" | caused by: %v", e.cause)
+	}
+
+	key := ""
+	if e.key {
+		key = "key for "
+	}
+
+	return fmt.Sprintf(
+		"invalid %sDataSourceStatus.%s: %s%s",
+		key,
+		e.field,
+		e.reason,
+		cause)
+}
+
+var _ error = DataSourceStatusValidationError{}
+
+var _ interface {
+	Field() string
+	Reason() string
+	Key() bool
+	Cause() error
+	ErrorName() string
+} = DataSourceStatusValidationError{}
+
+// Validate checks the field values on DownloadDataSourceRequest with the rules
+// defined in the proto definition for this message. If any rules are
+// violated, the first error encountered is returned, or nil if there are no violations.
+func (m *DownloadDataSourceRequest) Validate() error {
+	return m.validate(false)
+}
+
+// ValidateAll checks the field values on DownloadDataSourceRequest with the
+// rules defined in the proto definition for this message. If any rules are
+// violated, the result is a list of violation errors wrapped in
+// DownloadDataSourceRequestMultiError, or nil if none found.
+func (m *DownloadDataSourceRequest) ValidateAll() error {
+	return m.validate(true)
+}
+
+func (m *DownloadDataSourceRequest) validate(all bool) error {
+	if m == nil {
+		return nil
+	}
+
+	var errors []error
+
+	// no validation rules for Name
+
+	if len(errors) > 0 {
+		return DownloadDataSourceRequestMultiError(errors)
+	}
+
+	return nil
+}
+
+// DownloadDataSourceRequestMultiError is an error wrapping multiple validation
+// errors returned by DownloadDataSourceRequest.ValidateAll() if the
+// designated constraints aren't met.
+type DownloadDataSourceRequestMultiError []error
+
+// Error returns a concatenation of all the error messages it wraps.
+func (m DownloadDataSourceRequestMultiError) Error() string {
+	msgs := make([]string, 0, len(m))
+	for _, err := range m {
+		msgs = append(msgs, err.Error())
+	}
+	return strings.Join(msgs, "; ")
+}
+
+// AllErrors returns a list of validation violation errors.
+func (m DownloadDataSourceRequestMultiError) AllErrors() []error { return m }
+
+// DownloadDataSourceRequestValidationError is the validation error returned by
+// DownloadDataSourceRequest.Validate if the designated constraints aren't met.
+type DownloadDataSourceRequestValidationError struct {
+	field  string
+	reason string
+	cause  error
+	key    bool
+}
+
+// Field function returns field value.
+func (e DownloadDataSourceRequestValidationError) Field() string { return e.field }
+
+// Reason function returns reason value.
+func (e DownloadDataSourceRequestValidationError) Reason() string { return e.reason }
+
+// Cause function returns cause value.
+func (e DownloadDataSourceRequestValidationError) Cause() error { return e.cause }
+
+// Key function returns key value.
+func (e DownloadDataSourceRequestValidationError) Key() bool { return e.key }
+
+// ErrorName returns error name.
+func (e DownloadDataSourceRequestValidationError) ErrorName() string {
+	return "DownloadDataSourceRequestValidationError"
+}
+
+// Error satisfies the builtin error interface
+func (e DownloadDataSourceRequestValidationError) Error() string {
+	cause := ""
+	if e.cause != nil {
+		cause = fmt.Sprintf(" | caused by: %v", e.cause)
+	}
+
+	key := ""
+	if e.key {
+		key = "key for "
+	}
+
+	return fmt.Sprintf(
+		"invalid %sDownloadDataSourceRequest.%s: %s%s",
+		key,
+		e.field,
+		e.reason,
+		cause)
+}
+
+var _ error = DownloadDataSourceRequestValidationError{}
+
+var _ interface {
+	Field() string
+	Reason() string
+	Key() bool
+	Cause() error
+	ErrorName() string
+} = DownloadDataSourceRequestValidationError{}
+
+// Validate checks the field values on DownloadDataSourceResponse with the
+// rules defined in the proto definition for this message. If any rules are
+// violated, the first error encountered is returned, or nil if there are no violations.
+func (m *DownloadDataSourceResponse) Validate() error {
+	return m.validate(false)
+}
+
+// ValidateAll checks the field values on DownloadDataSourceResponse with the
+// rules defined in the proto definition for this message. If any rules are
+// violated, the result is a list of violation errors wrapped in
+// DownloadDataSourceResponseMultiError, or nil if none found.
+func (m *DownloadDataSourceResponse) ValidateAll() error {
+	return m.validate(true)
+}
+
+func (m *DownloadDataSourceResponse) validate(all bool) error {
+	if m == nil {
+		return nil
+	}
+
+	var errors []error
+
+	for idx, item := range m.GetSources() {
+		_, _ = idx, item
+
+		if all {
+			switch v := interface{}(item).(type) {
+			case interface{ ValidateAll() error }:
+				if err := v.ValidateAll(); err != nil {
+					errors = append(errors, DownloadDataSourceResponseValidationError{
+						field:  fmt.Sprintf("Sources[%v]", idx),
+						reason: "embedded message failed validation",
+						cause:  err,
+					})
+				}
+			case interface{ Validate() error }:
+				if err := v.Validate(); err != nil {
+					errors = append(errors, DownloadDataSourceResponseValidationError{
+						field:  fmt.Sprintf("Sources[%v]", idx),
+						reason: "embedded message failed validation",
+						cause:  err,
+					})
+				}
+			}
+		} else if v, ok := interface{}(item).(interface{ Validate() error }); ok {
+			if err := v.Validate(); err != nil {
+				return DownloadDataSourceResponseValidationError{
+					field:  fmt.Sprintf("Sources[%v]", idx),
+					reason: "embedded message failed validation",
+					cause:  err,
+				}
+			}
+		}
+
+	}
+
+	if len(errors) > 0 {
+		return DownloadDataSourceResponseMultiError(errors)
+	}
+
+	return nil
+}
+
+// DownloadDataSourceResponseMultiError is an error wrapping multiple
+// validation errors returned by DownloadDataSourceResponse.ValidateAll() if
+// the designated constraints aren't met.
+type DownloadDataSourceResponseMultiError []error
+
+// Error returns a concatenation of all the error messages it wraps.
+func (m DownloadDataSourceResponseMultiError) Error() string {
+	msgs := make([]string, 0, len(m))
+	for _, err := range m {
+		msgs = append(msgs, err.Error())
+	}
+	return strings.Join(msgs, "; ")
+}
+
+// AllErrors returns a list of validation violation errors.
+func (m DownloadDataSourceResponseMultiError) AllErrors() []error { return m }
+
+// DownloadDataSourceResponseValidationError is the validation error returned
+// by DownloadDataSourceResponse.Validate if the designated constraints aren't met.
+type DownloadDataSourceResponseValidationError struct {
+	field  string
+	reason string
+	cause  error
+	key    bool
+}
+
+// Field function returns field value.
+func (e DownloadDataSourceResponseValidationError) Field() string { return e.field }
+
+// Reason function returns reason value.
+func (e DownloadDataSourceResponseValidationError) Reason() string { return e.reason }
+
+// Cause function returns cause value.
+func (e DownloadDataSourceResponseValidationError) Cause() error { return e.cause }
+
+// Key function returns key value.
+func (e DownloadDataSourceResponseValidationError) Key() bool { return e.key }
+
+// ErrorName returns error name.
+func (e DownloadDataSourceResponseValidationError) ErrorName() string {
+	return "DownloadDataSourceResponseValidationError"
+}
+
+// Error satisfies the builtin error interface
+func (e DownloadDataSourceResponseValidationError) Error() string {
+	cause := ""
+	if e.cause != nil {
+		cause = fmt.Sprintf(" | caused by: %v", e.cause)
+	}
+
+	key := ""
+	if e.key {
+		key = "key for "
+	}
+
+	return fmt.Sprintf(
+		"invalid %sDownloadDataSourceResponse.%s: %s%s",
+		key,
+		e.field,
+		e.reason,
+		cause)
+}
+
+var _ error = DownloadDataSourceResponseValidationError{}
+
+var _ interface {
+	Field() string
+	Reason() string
+	Key() bool
+	Cause() error
+	ErrorName() string
+} = DownloadDataSourceResponseValidationError{}

--- a/pkg/api/pipeline/v1/pipeline_service.pb.validate.go
+++ b/pkg/api/pipeline/v1/pipeline_service.pb.validate.go
@@ -2813,6 +2813,8 @@ func (m *PipelineJob) validate(all bool) error {
 		}
 	}
 
+	// no validation rules for Term
+
 	if len(errors) > 0 {
 		return PipelineJobMultiError(errors)
 	}

--- a/pkg/api/pipeline/v1/pipelinev1connect/pipeline_service.connect.go
+++ b/pkg/api/pipeline/v1/pipelinev1connect/pipeline_service.connect.go
@@ -51,11 +51,28 @@ const (
 	// PipelineServiceGetEvidenceProcedure is the fully-qualified name of the PipelineService's
 	// GetEvidence RPC.
 	PipelineServiceGetEvidenceProcedure = "/pipeline.v1.PipelineService/GetEvidence"
+	// PipelineServiceSubmitJobProcedure is the fully-qualified name of the PipelineService's SubmitJob
+	// RPC.
+	PipelineServiceSubmitJobProcedure = "/pipeline.v1.PipelineService/SubmitJob"
+	// PipelineServiceGetJobProcedure is the fully-qualified name of the PipelineService's GetJob RPC.
+	PipelineServiceGetJobProcedure = "/pipeline.v1.PipelineService/GetJob"
+	// PipelineServiceListJobsProcedure is the fully-qualified name of the PipelineService's ListJobs
+	// RPC.
+	PipelineServiceListJobsProcedure = "/pipeline.v1.PipelineService/ListJobs"
+	// PipelineServiceCancelJobProcedure is the fully-qualified name of the PipelineService's CancelJob
+	// RPC.
+	PipelineServiceCancelJobProcedure = "/pipeline.v1.PipelineService/CancelJob"
+	// PipelineServiceListDataSourcesProcedure is the fully-qualified name of the PipelineService's
+	// ListDataSources RPC.
+	PipelineServiceListDataSourcesProcedure = "/pipeline.v1.PipelineService/ListDataSources"
+	// PipelineServiceDownloadDataSourceProcedure is the fully-qualified name of the PipelineService's
+	// DownloadDataSource RPC.
+	PipelineServiceDownloadDataSourceProcedure = "/pipeline.v1.PipelineService/DownloadDataSource"
 )
 
 // PipelineServiceClient is a client for the pipeline.v1.PipelineService service.
 type PipelineServiceClient interface {
-	// ProcessWord runs the full pipeline for a given term.
+	// ProcessWord runs the full pipeline for a given term (synchronous).
 	ProcessWord(context.Context, *connect.Request[v1.ProcessWordRequest]) (*connect.Response[v1.ProcessWordResponse], error)
 	// GetPipelineStatus returns the status of pipeline tasks for a word.
 	GetPipelineStatus(context.Context, *connect.Request[v1.GetPipelineStatusRequest]) (*connect.Response[v1.PipelineStatus], error)
@@ -67,6 +84,18 @@ type PipelineServiceClient interface {
 	ListWordSnapshots(context.Context, *connect.Request[v1.ListWordSnapshotsRequest]) (*connect.Response[v1.ListWordSnapshotsResponse], error)
 	// GetEvidence returns raw evidence for a word.
 	GetEvidence(context.Context, *connect.Request[v1.GetEvidenceRequest]) (*connect.Response[v1.GetEvidenceResponse], error)
+	// SubmitJob creates an async pipeline job for one or more terms.
+	SubmitJob(context.Context, *connect.Request[v1.SubmitJobRequest]) (*connect.Response[v1.PipelineJob], error)
+	// GetJob returns the details of a pipeline job.
+	GetJob(context.Context, *connect.Request[v1.GetJobRequest]) (*connect.Response[v1.PipelineJob], error)
+	// ListJobs returns a list of pipeline jobs.
+	ListJobs(context.Context, *connect.Request[v1.ListJobsRequest]) (*connect.Response[v1.ListJobsResponse], error)
+	// CancelJob cancels a pending or running pipeline job.
+	CancelJob(context.Context, *connect.Request[v1.CancelJobRequest]) (*connect.Response[v1.PipelineJob], error)
+	// ListDataSources returns the status of all pipeline data sources.
+	ListDataSources(context.Context, *connect.Request[v1.ListDataSourcesRequest]) (*connect.Response[v1.ListDataSourcesResponse], error)
+	// DownloadDataSource downloads a specific data source.
+	DownloadDataSource(context.Context, *connect.Request[v1.DownloadDataSourceRequest]) (*connect.Response[v1.DownloadDataSourceResponse], error)
 }
 
 // NewPipelineServiceClient constructs a client for the pipeline.v1.PipelineService service. By
@@ -116,17 +145,59 @@ func NewPipelineServiceClient(httpClient connect.HTTPClient, baseURL string, opt
 			connect.WithSchema(pipelineServiceMethods.ByName("GetEvidence")),
 			connect.WithClientOptions(opts...),
 		),
+		submitJob: connect.NewClient[v1.SubmitJobRequest, v1.PipelineJob](
+			httpClient,
+			baseURL+PipelineServiceSubmitJobProcedure,
+			connect.WithSchema(pipelineServiceMethods.ByName("SubmitJob")),
+			connect.WithClientOptions(opts...),
+		),
+		getJob: connect.NewClient[v1.GetJobRequest, v1.PipelineJob](
+			httpClient,
+			baseURL+PipelineServiceGetJobProcedure,
+			connect.WithSchema(pipelineServiceMethods.ByName("GetJob")),
+			connect.WithClientOptions(opts...),
+		),
+		listJobs: connect.NewClient[v1.ListJobsRequest, v1.ListJobsResponse](
+			httpClient,
+			baseURL+PipelineServiceListJobsProcedure,
+			connect.WithSchema(pipelineServiceMethods.ByName("ListJobs")),
+			connect.WithClientOptions(opts...),
+		),
+		cancelJob: connect.NewClient[v1.CancelJobRequest, v1.PipelineJob](
+			httpClient,
+			baseURL+PipelineServiceCancelJobProcedure,
+			connect.WithSchema(pipelineServiceMethods.ByName("CancelJob")),
+			connect.WithClientOptions(opts...),
+		),
+		listDataSources: connect.NewClient[v1.ListDataSourcesRequest, v1.ListDataSourcesResponse](
+			httpClient,
+			baseURL+PipelineServiceListDataSourcesProcedure,
+			connect.WithSchema(pipelineServiceMethods.ByName("ListDataSources")),
+			connect.WithClientOptions(opts...),
+		),
+		downloadDataSource: connect.NewClient[v1.DownloadDataSourceRequest, v1.DownloadDataSourceResponse](
+			httpClient,
+			baseURL+PipelineServiceDownloadDataSourceProcedure,
+			connect.WithSchema(pipelineServiceMethods.ByName("DownloadDataSource")),
+			connect.WithClientOptions(opts...),
+		),
 	}
 }
 
 // pipelineServiceClient implements PipelineServiceClient.
 type pipelineServiceClient struct {
-	processWord       *connect.Client[v1.ProcessWordRequest, v1.ProcessWordResponse]
-	getPipelineStatus *connect.Client[v1.GetPipelineStatusRequest, v1.PipelineStatus]
-	retryPhase        *connect.Client[v1.RetryPhaseRequest, v1.PipelineStatus]
-	getWordSnapshot   *connect.Client[v1.GetWordSnapshotRequest, v1.WordSnapshotResponse]
-	listWordSnapshots *connect.Client[v1.ListWordSnapshotsRequest, v1.ListWordSnapshotsResponse]
-	getEvidence       *connect.Client[v1.GetEvidenceRequest, v1.GetEvidenceResponse]
+	processWord        *connect.Client[v1.ProcessWordRequest, v1.ProcessWordResponse]
+	getPipelineStatus  *connect.Client[v1.GetPipelineStatusRequest, v1.PipelineStatus]
+	retryPhase         *connect.Client[v1.RetryPhaseRequest, v1.PipelineStatus]
+	getWordSnapshot    *connect.Client[v1.GetWordSnapshotRequest, v1.WordSnapshotResponse]
+	listWordSnapshots  *connect.Client[v1.ListWordSnapshotsRequest, v1.ListWordSnapshotsResponse]
+	getEvidence        *connect.Client[v1.GetEvidenceRequest, v1.GetEvidenceResponse]
+	submitJob          *connect.Client[v1.SubmitJobRequest, v1.PipelineJob]
+	getJob             *connect.Client[v1.GetJobRequest, v1.PipelineJob]
+	listJobs           *connect.Client[v1.ListJobsRequest, v1.ListJobsResponse]
+	cancelJob          *connect.Client[v1.CancelJobRequest, v1.PipelineJob]
+	listDataSources    *connect.Client[v1.ListDataSourcesRequest, v1.ListDataSourcesResponse]
+	downloadDataSource *connect.Client[v1.DownloadDataSourceRequest, v1.DownloadDataSourceResponse]
 }
 
 // ProcessWord calls pipeline.v1.PipelineService.ProcessWord.
@@ -159,9 +230,39 @@ func (c *pipelineServiceClient) GetEvidence(ctx context.Context, req *connect.Re
 	return c.getEvidence.CallUnary(ctx, req)
 }
 
+// SubmitJob calls pipeline.v1.PipelineService.SubmitJob.
+func (c *pipelineServiceClient) SubmitJob(ctx context.Context, req *connect.Request[v1.SubmitJobRequest]) (*connect.Response[v1.PipelineJob], error) {
+	return c.submitJob.CallUnary(ctx, req)
+}
+
+// GetJob calls pipeline.v1.PipelineService.GetJob.
+func (c *pipelineServiceClient) GetJob(ctx context.Context, req *connect.Request[v1.GetJobRequest]) (*connect.Response[v1.PipelineJob], error) {
+	return c.getJob.CallUnary(ctx, req)
+}
+
+// ListJobs calls pipeline.v1.PipelineService.ListJobs.
+func (c *pipelineServiceClient) ListJobs(ctx context.Context, req *connect.Request[v1.ListJobsRequest]) (*connect.Response[v1.ListJobsResponse], error) {
+	return c.listJobs.CallUnary(ctx, req)
+}
+
+// CancelJob calls pipeline.v1.PipelineService.CancelJob.
+func (c *pipelineServiceClient) CancelJob(ctx context.Context, req *connect.Request[v1.CancelJobRequest]) (*connect.Response[v1.PipelineJob], error) {
+	return c.cancelJob.CallUnary(ctx, req)
+}
+
+// ListDataSources calls pipeline.v1.PipelineService.ListDataSources.
+func (c *pipelineServiceClient) ListDataSources(ctx context.Context, req *connect.Request[v1.ListDataSourcesRequest]) (*connect.Response[v1.ListDataSourcesResponse], error) {
+	return c.listDataSources.CallUnary(ctx, req)
+}
+
+// DownloadDataSource calls pipeline.v1.PipelineService.DownloadDataSource.
+func (c *pipelineServiceClient) DownloadDataSource(ctx context.Context, req *connect.Request[v1.DownloadDataSourceRequest]) (*connect.Response[v1.DownloadDataSourceResponse], error) {
+	return c.downloadDataSource.CallUnary(ctx, req)
+}
+
 // PipelineServiceHandler is an implementation of the pipeline.v1.PipelineService service.
 type PipelineServiceHandler interface {
-	// ProcessWord runs the full pipeline for a given term.
+	// ProcessWord runs the full pipeline for a given term (synchronous).
 	ProcessWord(context.Context, *connect.Request[v1.ProcessWordRequest]) (*connect.Response[v1.ProcessWordResponse], error)
 	// GetPipelineStatus returns the status of pipeline tasks for a word.
 	GetPipelineStatus(context.Context, *connect.Request[v1.GetPipelineStatusRequest]) (*connect.Response[v1.PipelineStatus], error)
@@ -173,6 +274,18 @@ type PipelineServiceHandler interface {
 	ListWordSnapshots(context.Context, *connect.Request[v1.ListWordSnapshotsRequest]) (*connect.Response[v1.ListWordSnapshotsResponse], error)
 	// GetEvidence returns raw evidence for a word.
 	GetEvidence(context.Context, *connect.Request[v1.GetEvidenceRequest]) (*connect.Response[v1.GetEvidenceResponse], error)
+	// SubmitJob creates an async pipeline job for one or more terms.
+	SubmitJob(context.Context, *connect.Request[v1.SubmitJobRequest]) (*connect.Response[v1.PipelineJob], error)
+	// GetJob returns the details of a pipeline job.
+	GetJob(context.Context, *connect.Request[v1.GetJobRequest]) (*connect.Response[v1.PipelineJob], error)
+	// ListJobs returns a list of pipeline jobs.
+	ListJobs(context.Context, *connect.Request[v1.ListJobsRequest]) (*connect.Response[v1.ListJobsResponse], error)
+	// CancelJob cancels a pending or running pipeline job.
+	CancelJob(context.Context, *connect.Request[v1.CancelJobRequest]) (*connect.Response[v1.PipelineJob], error)
+	// ListDataSources returns the status of all pipeline data sources.
+	ListDataSources(context.Context, *connect.Request[v1.ListDataSourcesRequest]) (*connect.Response[v1.ListDataSourcesResponse], error)
+	// DownloadDataSource downloads a specific data source.
+	DownloadDataSource(context.Context, *connect.Request[v1.DownloadDataSourceRequest]) (*connect.Response[v1.DownloadDataSourceResponse], error)
 }
 
 // NewPipelineServiceHandler builds an HTTP handler from the service implementation. It returns the
@@ -218,6 +331,42 @@ func NewPipelineServiceHandler(svc PipelineServiceHandler, opts ...connect.Handl
 		connect.WithSchema(pipelineServiceMethods.ByName("GetEvidence")),
 		connect.WithHandlerOptions(opts...),
 	)
+	pipelineServiceSubmitJobHandler := connect.NewUnaryHandler(
+		PipelineServiceSubmitJobProcedure,
+		svc.SubmitJob,
+		connect.WithSchema(pipelineServiceMethods.ByName("SubmitJob")),
+		connect.WithHandlerOptions(opts...),
+	)
+	pipelineServiceGetJobHandler := connect.NewUnaryHandler(
+		PipelineServiceGetJobProcedure,
+		svc.GetJob,
+		connect.WithSchema(pipelineServiceMethods.ByName("GetJob")),
+		connect.WithHandlerOptions(opts...),
+	)
+	pipelineServiceListJobsHandler := connect.NewUnaryHandler(
+		PipelineServiceListJobsProcedure,
+		svc.ListJobs,
+		connect.WithSchema(pipelineServiceMethods.ByName("ListJobs")),
+		connect.WithHandlerOptions(opts...),
+	)
+	pipelineServiceCancelJobHandler := connect.NewUnaryHandler(
+		PipelineServiceCancelJobProcedure,
+		svc.CancelJob,
+		connect.WithSchema(pipelineServiceMethods.ByName("CancelJob")),
+		connect.WithHandlerOptions(opts...),
+	)
+	pipelineServiceListDataSourcesHandler := connect.NewUnaryHandler(
+		PipelineServiceListDataSourcesProcedure,
+		svc.ListDataSources,
+		connect.WithSchema(pipelineServiceMethods.ByName("ListDataSources")),
+		connect.WithHandlerOptions(opts...),
+	)
+	pipelineServiceDownloadDataSourceHandler := connect.NewUnaryHandler(
+		PipelineServiceDownloadDataSourceProcedure,
+		svc.DownloadDataSource,
+		connect.WithSchema(pipelineServiceMethods.ByName("DownloadDataSource")),
+		connect.WithHandlerOptions(opts...),
+	)
 	return "/pipeline.v1.PipelineService/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case PipelineServiceProcessWordProcedure:
@@ -232,6 +381,18 @@ func NewPipelineServiceHandler(svc PipelineServiceHandler, opts ...connect.Handl
 			pipelineServiceListWordSnapshotsHandler.ServeHTTP(w, r)
 		case PipelineServiceGetEvidenceProcedure:
 			pipelineServiceGetEvidenceHandler.ServeHTTP(w, r)
+		case PipelineServiceSubmitJobProcedure:
+			pipelineServiceSubmitJobHandler.ServeHTTP(w, r)
+		case PipelineServiceGetJobProcedure:
+			pipelineServiceGetJobHandler.ServeHTTP(w, r)
+		case PipelineServiceListJobsProcedure:
+			pipelineServiceListJobsHandler.ServeHTTP(w, r)
+		case PipelineServiceCancelJobProcedure:
+			pipelineServiceCancelJobHandler.ServeHTTP(w, r)
+		case PipelineServiceListDataSourcesProcedure:
+			pipelineServiceListDataSourcesHandler.ServeHTTP(w, r)
+		case PipelineServiceDownloadDataSourceProcedure:
+			pipelineServiceDownloadDataSourceHandler.ServeHTTP(w, r)
 		default:
 			http.NotFound(w, r)
 		}
@@ -263,4 +424,28 @@ func (UnimplementedPipelineServiceHandler) ListWordSnapshots(context.Context, *c
 
 func (UnimplementedPipelineServiceHandler) GetEvidence(context.Context, *connect.Request[v1.GetEvidenceRequest]) (*connect.Response[v1.GetEvidenceResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("pipeline.v1.PipelineService.GetEvidence is not implemented"))
+}
+
+func (UnimplementedPipelineServiceHandler) SubmitJob(context.Context, *connect.Request[v1.SubmitJobRequest]) (*connect.Response[v1.PipelineJob], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("pipeline.v1.PipelineService.SubmitJob is not implemented"))
+}
+
+func (UnimplementedPipelineServiceHandler) GetJob(context.Context, *connect.Request[v1.GetJobRequest]) (*connect.Response[v1.PipelineJob], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("pipeline.v1.PipelineService.GetJob is not implemented"))
+}
+
+func (UnimplementedPipelineServiceHandler) ListJobs(context.Context, *connect.Request[v1.ListJobsRequest]) (*connect.Response[v1.ListJobsResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("pipeline.v1.PipelineService.ListJobs is not implemented"))
+}
+
+func (UnimplementedPipelineServiceHandler) CancelJob(context.Context, *connect.Request[v1.CancelJobRequest]) (*connect.Response[v1.PipelineJob], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("pipeline.v1.PipelineService.CancelJob is not implemented"))
+}
+
+func (UnimplementedPipelineServiceHandler) ListDataSources(context.Context, *connect.Request[v1.ListDataSourcesRequest]) (*connect.Response[v1.ListDataSourcesResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("pipeline.v1.PipelineService.ListDataSources is not implemented"))
+}
+
+func (UnimplementedPipelineServiceHandler) DownloadDataSource(context.Context, *connect.Request[v1.DownloadDataSourceRequest]) (*connect.Response[v1.DownloadDataSourceResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("pipeline.v1.PipelineService.DownloadDataSource is not implemented"))
 }


### PR DESCRIPTION
## Summary

Adds a full ConnectRPC API layer for the vocabulary distillation pipeline and refactors the CLI to use it, replacing direct database access. This ensures the CLI and future frontend share the same API contract.

### What changed

**Proto & API (6 new RPCs)**
- `SubmitJob` — create async pipeline jobs (single word, batch terms, or built-in wordbook)
- `GetJob` / `ListJobs` — query job status and progress
- `CancelJob` — cancel pending or running jobs
- `ListDataSources` / `DownloadDataSource` — manage offline data sources (ConceptNet, ECDICT, WordNet, Moby)

The existing 6 word-level RPCs (`ProcessWord`, `GetPipelineStatus`, `RetryPhase`, `GetWordSnapshot`, `ListWordSnapshots`, `GetEvidence`) are preserved. The service now exposes 12 RPCs total.

**Usecase layer**
- Expanded `PipelineService` from a job-only facade into a full query facade covering snapshots, evidence, pipeline status, and data source management
- Constructor now accepts 7 dependencies (added `WordSnapshotRepository`, `EvidenceRepository`, `LemmaRepository`, `datasource.Manager`)
- Added `CancelJob`, `GetPipelineStatus`, `GetWordSnapshot`, `ListWordSnapshots`, `GetEvidence`, `ListDataSources`, `DownloadDataSource` methods

**Repository layer**
- Added `List()` to `WordSnapshotRepository` with language/quality-score filtering, ordering, and pagination

**ConnectRPC handler & mapping**
- New `pipeline_service.go` handler implementing all 12 RPCs (with `ProcessWord`/`RetryPhase` returning `Unimplemented` — they require the full pipeline orchestrator)
- New `mapping/pipeline.go` with entity↔protobuf converters for jobs, snapshots, evidence, pipeline status, and data source status
- Pipeline error types mapped to appropriate gRPC status codes in `error.go`

**DI & server registration**
- Pipeline handler wired via Google Wire with `provideDataSourceManager`
- Registered in `server.go` with read-only pipeline procedures added to auth whitelist

**CLI refactor**
- All pipeline commands (`submit`, `jobs`, `job`, `source list`, `source download`) now use `pipelinev1connect.PipelineServiceClient` instead of direct DB access
- Added `--server` flag (default `http://localhost:8080`) on the `pipeline` command
- Added `cancel` subcommand
- Job detail view fetches stage info via `GetPipelineStatus` RPC with duration display

### Why

The pipeline CLI previously bypassed the API and accessed the database directly. This made it impossible for a future web frontend to share the same behavior, and meant business logic was duplicated between the CLI and the (then-incomplete) API. By completing the API and routing the CLI through it, all clients get consistent behavior through a single code path.

### Files changed (16)

| Area | Files |
|------|-------|
| Proto | `api/proto/pipeline/v1/pipeline_service.proto` |
| Generated | `pkg/api/pipeline/v1/*.go` (3 files) |
| Handler | `internal/adapter/connectrpc/pipeline_service.go` (new) |
| Mapping | `internal/adapter/mapping/pipeline.go` (new), `error.go` |
| Repository | `internal/repository/word_snapshot_repository.go`, `internal/adapter/repository/word_snapshot_repo.go` |
| Usecase | `internal/usecase/pipeline/service.go` |
| Entity | `internal/entity/errors.go` |
| DI | `internal/app/wire.go`, `wire_gen.go`, `wire_providers.go` |
| Server | `internal/infrastructure/server/server.go` |
| CLI | `cmd/pipeline.go` |

---

This PR was written using [Vibe Kanban](https://vibekanban.com)