### PR TITLE
feat: add pipeline worker pool metrics and monitoring CLI (Vibe Kanban)

### DIFF
--- a/cmd/pipeline.go
+++ b/cmd/pipeline.go
@@ -2,7 +2,9 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"net/http"
 	"os"
 	"strconv"
 	"strings"
@@ -417,6 +419,163 @@ func newPipelineDeps() (*pipelineDeps, error) {
 	return &pipelineDeps{svc: svc, cleanup: cleanup}, nil
 }
 
+// statsCmd shows pipeline worker pool statistics
+var statsCmd = &cobra.Command{
+	Use:   "stats",
+	Short: "Show pipeline worker pool statistics",
+	Long: `Query the running server's metrics endpoint to display:
+  - Worker pool metrics (jobs processed, rate, avg duration)
+  - Queue status (pending, running, completed, failed)
+  - Estimated remaining time
+
+The server must be running for this command to work.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		serverURL, _ := cmd.Flags().GetString("url")
+		watch, _ := cmd.Flags().GetBool("watch")
+
+		if watch {
+			return runStatsWatch(serverURL)
+		}
+		return runStatsOnce(serverURL)
+	},
+}
+
+func runStatsOnce(serverURL string) error {
+	stats, err := fetchPipelineStats(serverURL)
+	if err != nil {
+		return err
+	}
+	printStats(stats)
+	return nil
+}
+
+func runStatsWatch(serverURL string) error {
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
+
+	// Print initial stats
+	if err := runStatsOnce(serverURL); err != nil {
+		return err
+	}
+
+	fmt.Println("\nWatching... (press Ctrl+C to stop)")
+
+	for range ticker.C {
+		// Clear screen and move cursor to top
+		fmt.Print("\033[H\033[2J")
+		if err := runStatsOnce(serverURL); err != nil {
+			fmt.Printf("Error: %v\n", err)
+		}
+		fmt.Println("\nWatching... (press Ctrl+C to stop)")
+	}
+	return nil
+}
+
+// PipelineStatsResponse mirrors server.PipelineStatsResponse for CLI parsing.
+type PipelineStatsResponse struct {
+	Worker                    WorkerMetrics `json:"worker"`
+	Queue                     QueueStats    `json:"queue"`
+	EstimatedRemainingSeconds float64       `json:"estimated_remaining_seconds"`
+}
+
+type WorkerMetrics struct {
+	UptimeSeconds       float64 `json:"uptime_seconds"`
+	JobsProcessed       int64   `json:"jobs_processed"`
+	JobsSucceeded       int64   `json:"jobs_succeeded"`
+	JobsFailed          int64   `json:"jobs_failed"`
+	JobsPerMinute       float64 `json:"jobs_per_minute"`
+	AvgDurationMs       float64 `json:"avg_duration_ms"`
+	RecentJobsPerMinute float64 `json:"recent_jobs_per_minute"`
+	RecentAvgDurationMs float64 `json:"recent_avg_duration_ms"`
+}
+
+type QueueStats struct {
+	Pending   int64 `json:"pending"`
+	Running   int64 `json:"running"`
+	Completed int64 `json:"completed"`
+	Failed    int64 `json:"failed"`
+	Paused    int64 `json:"paused"`
+	Cancelled int64 `json:"cancelled"`
+	Total     int64 `json:"total"`
+}
+
+func fetchPipelineStats(serverURL string) (*PipelineStatsResponse, error) {
+	resp, err := http.Get(serverURL + "/metrics/pipeline")
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to server: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("server returned status %d", resp.StatusCode)
+	}
+
+	var stats PipelineStatsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&stats); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &stats, nil
+}
+
+func printStats(stats *PipelineStatsResponse) {
+	now := time.Now().Format("2006-01-02 15:04:05")
+	fmt.Printf("Pipeline Stats (%s)\n", now)
+	fmt.Println(strings.Repeat("=", 50))
+
+	// Worker metrics
+	fmt.Println("\n📊 Worker Pool:")
+	fmt.Printf("  Uptime:         %s\n", formatDuration(stats.Worker.UptimeSeconds))
+	fmt.Printf("  Processed:      %d (✓ %d, ✗ %d)\n",
+		stats.Worker.JobsProcessed, stats.Worker.JobsSucceeded, stats.Worker.JobsFailed)
+	fmt.Printf("  Rate (5min):    %.1f jobs/min\n", stats.Worker.JobsPerMinute)
+	fmt.Printf("  Rate (1min):    %.1f jobs/min\n", stats.Worker.RecentJobsPerMinute)
+	fmt.Printf("  Avg Duration:   %.0f ms\n", stats.Worker.AvgDurationMs)
+
+	// Queue stats
+	fmt.Println("\n📋 Queue:")
+	fmt.Printf("  Pending:        %d\n", stats.Queue.Pending)
+	fmt.Printf("  Running:        %d\n", stats.Queue.Running)
+	fmt.Printf("  Completed:      %d\n", stats.Queue.Completed)
+	fmt.Printf("  Failed:         %d\n", stats.Queue.Failed)
+	if stats.Queue.Paused > 0 {
+		fmt.Printf("  Paused:         %d\n", stats.Queue.Paused)
+	}
+	if stats.Queue.Cancelled > 0 {
+		fmt.Printf("  Cancelled:      %d\n", stats.Queue.Cancelled)
+	}
+	fmt.Printf("  Total:          %d\n", stats.Queue.Total)
+
+	// Progress
+	remaining := stats.Queue.Pending + stats.Queue.Running
+	if stats.Queue.Total > 0 {
+		completed := stats.Queue.Completed + stats.Queue.Failed + stats.Queue.Cancelled
+		progress := float64(completed) / float64(stats.Queue.Total) * 100
+		fmt.Printf("\n⏱️  Progress:      %.1f%% (%d/%d)\n", progress, completed, stats.Queue.Total)
+	}
+
+	// ETA
+	if stats.EstimatedRemainingSeconds > 0 && remaining > 0 {
+		fmt.Printf("🕐 ETA:           ~%s (%d jobs remaining)\n",
+			formatDuration(stats.EstimatedRemainingSeconds), remaining)
+	}
+}
+
+func formatDuration(seconds float64) string {
+	d := time.Duration(seconds * float64(time.Second))
+	if d < time.Minute {
+		return d.Round(time.Second).String()
+	}
+	if d < time.Hour {
+		mins := int(d.Minutes())
+		secs := int(d.Seconds()) % 60
+		return fmt.Sprintf("%dm%ds", mins, secs)
+	}
+	hours := int(d.Hours())
+	mins := int(d.Minutes()) % 60
+	return fmt.Sprintf("%dh%dm", hours, mins)
+}
+
 // resolveWordbook finds a builtin wordbook by name or ID and returns its terms.
 func resolveWordbook(nameOrID string) ([]string, string, error) {
 	builtins := wordbook.GetBuiltinWordbooks()
@@ -471,4 +630,9 @@ func init() {
 	pipelineCmd.AddCommand(jobControlCmd("resume", "Resume a paused job", entity.JobActionResume, "resumed"))
 	pipelineCmd.AddCommand(jobControlCmd("cancel", "Cancel a pending, running, or paused job", entity.JobActionCancel, "cancelled"))
 	pipelineCmd.AddCommand(jobControlCmd("retry", "Retry a failed or cancelled job", entity.JobActionRetry, "queued for retry"))
+
+	// Stats command
+	pipelineCmd.AddCommand(statsCmd)
+	statsCmd.Flags().String("url", "http://localhost:8080", "Server URL")
+	statsCmd.Flags().BoolP("watch", "w", false, "Watch mode (refresh every 2 seconds)")
 }

--- a/cmd/pipeline.go
+++ b/cmd/pipeline.go
@@ -423,10 +423,7 @@ func newPipelineDeps() (*pipelineDeps, error) {
 var statsCmd = &cobra.Command{
 	Use:   "stats",
 	Short: "Show pipeline worker pool statistics",
-	Long: `Query the running server's metrics endpoint to display:
-  - Worker pool metrics (jobs processed, rate, avg duration)
-  - Queue status (pending, running, completed, failed)
-  - Estimated remaining time
+	Long: `Query the running server's metrics endpoint to display worker pool metrics (uptime, jobs processed, rate, average duration).
 
 The server must be running for this command to work.`,
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/pipeline.go
+++ b/cmd/pipeline.go
@@ -2,8 +2,8 @@ package cmd
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"strconv"
@@ -471,36 +471,18 @@ func runStatsWatch(serverURL string) error {
 	return nil
 }
 
-// PipelineStatsResponse mirrors server.PipelineStatsResponse for CLI parsing.
-type PipelineStatsResponse struct {
-	Worker                    WorkerMetrics `json:"worker"`
-	Queue                     QueueStats    `json:"queue"`
-	EstimatedRemainingSeconds float64       `json:"estimated_remaining_seconds"`
+// PipelineStats holds parsed Prometheus metrics for CLI display.
+type PipelineStats struct {
+	UptimeSeconds       float64
+	JobsSucceeded       float64
+	JobsFailed          float64
+	JobsPerMinute       float64
+	JobDurationSum      float64
+	JobDurationCount    float64
 }
 
-type WorkerMetrics struct {
-	UptimeSeconds       float64 `json:"uptime_seconds"`
-	JobsProcessed       int64   `json:"jobs_processed"`
-	JobsSucceeded       int64   `json:"jobs_succeeded"`
-	JobsFailed          int64   `json:"jobs_failed"`
-	JobsPerMinute       float64 `json:"jobs_per_minute"`
-	AvgDurationMs       float64 `json:"avg_duration_ms"`
-	RecentJobsPerMinute float64 `json:"recent_jobs_per_minute"`
-	RecentAvgDurationMs float64 `json:"recent_avg_duration_ms"`
-}
-
-type QueueStats struct {
-	Pending   int64 `json:"pending"`
-	Running   int64 `json:"running"`
-	Completed int64 `json:"completed"`
-	Failed    int64 `json:"failed"`
-	Paused    int64 `json:"paused"`
-	Cancelled int64 `json:"cancelled"`
-	Total     int64 `json:"total"`
-}
-
-func fetchPipelineStats(serverURL string) (*PipelineStatsResponse, error) {
-	resp, err := http.Get(serverURL + "/metrics/pipeline")
+func fetchPipelineStats(serverURL string) (*PipelineStats, error) {
+	resp, err := http.Get(serverURL + "/metrics")
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to server: %w", err)
 	}
@@ -510,54 +492,64 @@ func fetchPipelineStats(serverURL string) (*PipelineStatsResponse, error) {
 		return nil, fmt.Errorf("server returned status %d", resp.StatusCode)
 	}
 
-	var stats PipelineStatsResponse
-	if err := json.NewDecoder(resp.Body).Decode(&stats); err != nil {
-		return nil, fmt.Errorf("failed to parse response: %w", err)
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
 	}
 
-	return &stats, nil
+	stats := &PipelineStats{}
+	lines := strings.Split(string(body), "\n")
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		// Parse metric lines
+		switch {
+		case strings.HasPrefix(line, "vocnet_pipeline_uptime_seconds "):
+			stats.UptimeSeconds = parseMetricValue(line)
+		case strings.HasPrefix(line, "vocnet_pipeline_jobs_per_minute "):
+			stats.JobsPerMinute = parseMetricValue(line)
+		case strings.Contains(line, `vocnet_pipeline_jobs_processed_total{status="succeeded"}`):
+			stats.JobsSucceeded = parseMetricValue(line)
+		case strings.Contains(line, `vocnet_pipeline_jobs_processed_total{status="failed"}`):
+			stats.JobsFailed = parseMetricValue(line)
+		case strings.HasPrefix(line, "vocnet_pipeline_job_duration_seconds_sum "):
+			stats.JobDurationSum = parseMetricValue(line)
+		case strings.HasPrefix(line, "vocnet_pipeline_job_duration_seconds_count "):
+			stats.JobDurationCount = parseMetricValue(line)
+		}
+	}
+
+	return stats, nil
 }
 
-func printStats(stats *PipelineStatsResponse) {
+func parseMetricValue(line string) float64 {
+	parts := strings.Fields(line)
+	if len(parts) >= 2 {
+		val, _ := strconv.ParseFloat(parts[len(parts)-1], 64)
+		return val
+	}
+	return 0
+}
+
+func printStats(stats *PipelineStats) {
 	now := time.Now().Format("2006-01-02 15:04:05")
 	fmt.Printf("Pipeline Stats (%s)\n", now)
 	fmt.Println(strings.Repeat("=", 50))
 
 	// Worker metrics
 	fmt.Println("\n📊 Worker Pool:")
-	fmt.Printf("  Uptime:         %s\n", formatDuration(stats.Worker.UptimeSeconds))
-	fmt.Printf("  Processed:      %d (✓ %d, ✗ %d)\n",
-		stats.Worker.JobsProcessed, stats.Worker.JobsSucceeded, stats.Worker.JobsFailed)
-	fmt.Printf("  Rate (5min):    %.1f jobs/min\n", stats.Worker.JobsPerMinute)
-	fmt.Printf("  Rate (1min):    %.1f jobs/min\n", stats.Worker.RecentJobsPerMinute)
-	fmt.Printf("  Avg Duration:   %.0f ms\n", stats.Worker.AvgDurationMs)
+	fmt.Printf("  Uptime:         %s\n", formatDuration(stats.UptimeSeconds))
 
-	// Queue stats
-	fmt.Println("\n📋 Queue:")
-	fmt.Printf("  Pending:        %d\n", stats.Queue.Pending)
-	fmt.Printf("  Running:        %d\n", stats.Queue.Running)
-	fmt.Printf("  Completed:      %d\n", stats.Queue.Completed)
-	fmt.Printf("  Failed:         %d\n", stats.Queue.Failed)
-	if stats.Queue.Paused > 0 {
-		fmt.Printf("  Paused:         %d\n", stats.Queue.Paused)
-	}
-	if stats.Queue.Cancelled > 0 {
-		fmt.Printf("  Cancelled:      %d\n", stats.Queue.Cancelled)
-	}
-	fmt.Printf("  Total:          %d\n", stats.Queue.Total)
+	total := int64(stats.JobsSucceeded + stats.JobsFailed)
+	fmt.Printf("  Processed:      %d (✓ %.0f, ✗ %.0f)\n", total, stats.JobsSucceeded, stats.JobsFailed)
+	fmt.Printf("  Rate (1min):    %.1f jobs/min\n", stats.JobsPerMinute)
 
-	// Progress
-	remaining := stats.Queue.Pending + stats.Queue.Running
-	if stats.Queue.Total > 0 {
-		completed := stats.Queue.Completed + stats.Queue.Failed + stats.Queue.Cancelled
-		progress := float64(completed) / float64(stats.Queue.Total) * 100
-		fmt.Printf("\n⏱️  Progress:      %.1f%% (%d/%d)\n", progress, completed, stats.Queue.Total)
-	}
-
-	// ETA
-	if stats.EstimatedRemainingSeconds > 0 && remaining > 0 {
-		fmt.Printf("🕐 ETA:           ~%s (%d jobs remaining)\n",
-			formatDuration(stats.EstimatedRemainingSeconds), remaining)
+	if stats.JobDurationCount > 0 {
+		avgMs := (stats.JobDurationSum / stats.JobDurationCount) * 1000
+		fmt.Printf("  Avg Duration:   %.0f ms\n", avgMs)
 	}
 }
 

--- a/cmd/pipeline.go
+++ b/cmd/pipeline.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"io"
 	"net/http"
 	"os"
 	"strconv"
@@ -11,6 +10,7 @@ import (
 	"time"
 
 	"github.com/olekukonko/tablewriter"
+	"github.com/prometheus/common/expfmt"
 	"github.com/spf13/cobra"
 
 	"github.com/eslsoft/vocnet/internal/adapter/repository"
@@ -489,46 +489,55 @@ func fetchPipelineStats(serverURL string) (*PipelineStats, error) {
 		return nil, fmt.Errorf("server returned status %d", resp.StatusCode)
 	}
 
-	body, err := io.ReadAll(resp.Body)
+	// Parse Prometheus text format using official parser
+	var parser expfmt.TextParser
+	metricFamilies, err := parser.TextToMetricFamilies(resp.Body)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read response: %w", err)
+		return nil, fmt.Errorf("failed to parse metrics: %w", err)
 	}
 
 	stats := &PipelineStats{}
-	lines := strings.Split(string(body), "\n")
-	for _, line := range lines {
-		line = strings.TrimSpace(line)
-		if line == "" || strings.HasPrefix(line, "#") {
-			continue
-		}
 
-		// Parse metric lines
-		switch {
-		case strings.HasPrefix(line, "vocnet_pipeline_uptime_seconds "):
-			stats.UptimeSeconds = parseMetricValue(line)
-		case strings.HasPrefix(line, "vocnet_pipeline_jobs_per_minute "):
-			stats.JobsPerMinute = parseMetricValue(line)
-		case strings.Contains(line, `vocnet_pipeline_jobs_processed_total{status="succeeded"}`):
-			stats.JobsSucceeded = parseMetricValue(line)
-		case strings.Contains(line, `vocnet_pipeline_jobs_processed_total{status="failed"}`):
-			stats.JobsFailed = parseMetricValue(line)
-		case strings.HasPrefix(line, "vocnet_pipeline_job_duration_seconds_sum "):
-			stats.JobDurationSum = parseMetricValue(line)
-		case strings.HasPrefix(line, "vocnet_pipeline_job_duration_seconds_count "):
-			stats.JobDurationCount = parseMetricValue(line)
+	// Extract uptime
+	if mf, ok := metricFamilies["vocnet_pipeline_uptime_seconds"]; ok {
+		for _, m := range mf.GetMetric() {
+			stats.UptimeSeconds = m.GetGauge().GetValue()
+		}
+	}
+
+	// Extract jobs per minute
+	if mf, ok := metricFamilies["vocnet_pipeline_jobs_per_minute"]; ok {
+		for _, m := range mf.GetMetric() {
+			stats.JobsPerMinute = m.GetGauge().GetValue()
+		}
+	}
+
+	// Extract jobs processed by status
+	if mf, ok := metricFamilies["vocnet_pipeline_jobs_processed_total"]; ok {
+		for _, m := range mf.GetMetric() {
+			for _, label := range m.GetLabel() {
+				if label.GetName() == "status" {
+					switch label.GetValue() {
+					case "succeeded":
+						stats.JobsSucceeded = m.GetCounter().GetValue()
+					case "failed":
+						stats.JobsFailed = m.GetCounter().GetValue()
+					}
+				}
+			}
+		}
+	}
+
+	// Extract job duration histogram
+	if mf, ok := metricFamilies["vocnet_pipeline_job_duration_seconds"]; ok {
+		for _, m := range mf.GetMetric() {
+			h := m.GetHistogram()
+			stats.JobDurationSum = h.GetSampleSum()
+			stats.JobDurationCount = float64(h.GetSampleCount())
 		}
 	}
 
 	return stats, nil
-}
-
-func parseMetricValue(line string) float64 {
-	parts := strings.Fields(line)
-	if len(parts) >= 2 {
-		val, _ := strconv.ParseFloat(parts[len(parts)-1], 64)
-		return val
-	}
-	return 0
 }
 
 func printStats(stats *PipelineStats) {

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -47,6 +47,7 @@ import (
 	"github.com/eslsoft/vocnet/internal/infrastructure/config"
 	entdb "github.com/eslsoft/vocnet/internal/infrastructure/database/ent"
 	"github.com/eslsoft/vocnet/internal/infrastructure/datasource"
+	"github.com/eslsoft/vocnet/internal/infrastructure/server"
 	"github.com/eslsoft/vocnet/internal/usecase/pipeline"
 	"github.com/eslsoft/vocnet/pkg/safeconv"
 	"github.com/eslsoft/vocnet/pkg/wordbook"
@@ -85,6 +86,13 @@ var serveCmd = &cobra.Command{
 
 		// Build server
 		srv := container.Server
+
+		// Register pipeline metrics endpoint
+		if workerPool != nil {
+			jobRepo := repository.NewPipelineJobRepository(container.EntClient)
+			metricsHandler := server.NewMetricsHandler(workerPool, jobRepo)
+			srv.RegisterMetricsHandler(metricsHandler)
+		}
 
 		// Run gRPC & HTTP concurrently
 		errCh := make(chan error, 2)

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -87,12 +87,8 @@ var serveCmd = &cobra.Command{
 		// Build server
 		srv := container.Server
 
-		// Register pipeline metrics endpoint
-		if workerPool != nil {
-			jobRepo := repository.NewPipelineJobRepository(container.EntClient)
-			metricsHandler := server.NewMetricsHandler(workerPool, jobRepo)
-			srv.RegisterMetricsHandler(metricsHandler)
-		}
+		// Register prometheus metrics endpoint (metrics are auto-registered by WorkerPool)
+		srv.RegisterMetricsHandler(server.MetricsHandler())
 
 		// Run gRPC & HTTP concurrently
 		errCh := make(chan error, 2)

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,9 @@ require (
 	github.com/agext/levenshtein v1.2.3 // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.1 // indirect
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
+	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bmatcuk/doublestar v1.3.4 // indirect
+	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/clipperhouse/displaywidth v0.9.0 // indirect
 	github.com/clipperhouse/stringish v0.1.1 // indirect
 	github.com/clipperhouse/uax29/v2 v2.5.0 // indirect
@@ -63,12 +65,17 @@ require (
 	github.com/mattn/go-runewidth v0.0.19 // indirect
 	github.com/mattn/go-sqlite3 v1.14.33 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
+	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/olekukonko/cat v0.0.0-20250911104152-50322a0618f6 // indirect
 	github.com/olekukonko/errors v1.1.0 // indirect
 	github.com/olekukonko/ll v0.1.4-0.20260115111900-9e59c2286df0 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/prometheus/client_golang v1.23.2 // indirect
+	github.com/prometheus/client_model v0.6.2 // indirect
+	github.com/prometheus/common v0.66.1 // indirect
+	github.com/prometheus/procfs v0.16.1 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/sagikazarmark/locafero v0.12.0 // indirect
 	github.com/spf13/afero v1.15.0 // indirect
@@ -76,6 +83,7 @@ require (
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/zclconf/go-cty v1.17.0 // indirect
 	github.com/zclconf/go-cty-yaml v1.2.0 // indirect
+	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/mod v0.32.0 // indirect
 	golang.org/x/sync v0.19.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -20,8 +20,12 @@ github.com/antlr4-go/antlr/v4 v4.13.1 h1:SqQKkuVZ+zWkMMNkjy5FZe5mr5WURWnlpmOuzYW
 github.com/antlr4-go/antlr/v4 v4.13.1/go.mod h1:GKmUxMtwp6ZgGwZSva4eWPC5mS6vUAmOABFgjdkM7Nw=
 github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew1u1fNQOlOtuGxQY=
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=
+github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
+github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bmatcuk/doublestar v1.3.4 h1:gPypJ5xD31uhX6Tf54sDPUOBXTqKH4c9aPY66CyQrS0=
 github.com/bmatcuk/doublestar v1.3.4/go.mod h1:wiQtGV+rzVYxB7WIlirSN++5HPtPlXEo9MEoZQC/PmE=
+github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
+github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/clipperhouse/displaywidth v0.9.0 h1:Qb4KOhYwRiN3viMv1v/3cTBlz3AcAZX3+y9OLhMtAtA=
 github.com/clipperhouse/displaywidth v0.9.0/go.mod h1:aCAAqTlh4GIVkhQnJpbL0T/WfcrJXHcj8C0yjYcjOZA=
 github.com/clipperhouse/stringish v0.1.1 h1:+NSqMOr3GR6k1FdRhhnXrLfztGzuG+VuFDfatpWHKCs=
@@ -106,6 +110,8 @@ github.com/mattn/go-sqlite3 v1.14.33 h1:A5blZ5ulQo2AtayQ9/limgHEkFreKj1Dv226a1K7
 github.com/mattn/go-sqlite3 v1.14.33/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/mitchellh/go-wordwrap v1.0.1 h1:TLuKupo69TCn6TQSyGxwI1EblZZEsQ0vMlAFQflz0v0=
 github.com/mitchellh/go-wordwrap v1.0.1/go.mod h1:R62XHJLzvMFRBbcrT7m7WgmE1eOyTSsCt+hzestvNj0=
+github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
+github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
 github.com/olekukonko/cat v0.0.0-20250911104152-50322a0618f6 h1:zrbMGy9YXpIeTnGj4EljqMiZsIcE09mmF8XsD5AYOJc=
@@ -122,6 +128,14 @@ github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0
 github.com/pelletier/go-toml/v2 v2.2.4/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/prometheus/client_golang v1.23.2 h1:Je96obch5RDVy3FDMndoUsjAhG5Edi49h0RJWRi/o0o=
+github.com/prometheus/client_golang v1.23.2/go.mod h1:Tb1a6LWHB3/SPIzCoaDXI4I8UHKeFTEQ1YCr+0Gyqmg=
+github.com/prometheus/client_model v0.6.2 h1:oBsgwpGs7iVziMvrGhE53c/GrLUsZdHnqNwqPLxwZyk=
+github.com/prometheus/client_model v0.6.2/go.mod h1:y3m2F6Gdpfy6Ut/GBsUqTWZqCUvMVzSfMLjcu6wAwpE=
+github.com/prometheus/common v0.66.1 h1:h5E0h5/Y8niHc5DlaLlWLArTQI7tMrsfQjHV+d9ZoGs=
+github.com/prometheus/common v0.66.1/go.mod h1:gcaUsgf3KfRSwHY4dIMXLPV0K/Wg1oZ8+SbZk/HH/dA=
+github.com/prometheus/procfs v0.16.1 h1:hZ15bTNuirocR6u0JZ6BAHHmwS1p8B4P6MRqxtzMyRg=
+github.com/prometheus/procfs v0.16.1/go.mod h1:teAbpZRB1iIAJYREa1LsoWUXykVXA1KlTmWl8x/U+Is=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
@@ -170,6 +184,8 @@ go.opentelemetry.io/otel/sdk/metric v1.38.0 h1:aSH66iL0aZqo//xXzQLYozmWrXxyFkBJ6
 go.opentelemetry.io/otel/sdk/metric v1.38.0/go.mod h1:dg9PBnW9XdQ1Hd6ZnRz689CbtrUp0wMMs9iPcgT9EZA=
 go.opentelemetry.io/otel/trace v1.38.0 h1:Fxk5bKrDZJUH+AMyyIXGcFAPah0oRcT+LuNtJrmcNLE=
 go.opentelemetry.io/otel/trace v1.38.0/go.mod h1:j1P9ivuFsTceSWe1oY+EeW3sc+Pp42sO++GHkg4wwhs=
+go.yaml.in/yaml/v2 v2.4.2 h1:DzmwEr2rDGHl7lsFgAHxmNz/1NlQ7xLIrlN2h5d1eGI=
+go.yaml.in/yaml/v2 v2.4.2/go.mod h1:081UH+NErpNdqlCXm3TtEran0rJZGxAYx9hb/ELlsPU=
 go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/internal/infrastructure/server/metrics.go
+++ b/internal/infrastructure/server/metrics.go
@@ -3,72 +3,11 @@ package server
 import (
 	"net/http"
 
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
-// PipelineMetrics holds Prometheus metrics for the pipeline worker pool.
-type PipelineMetrics struct {
-	JobsProcessed *prometheus.CounterVec
-	JobsTotal     *prometheus.GaugeVec
-	JobDuration   prometheus.Histogram
-	JobsPerMinute prometheus.Gauge
-	Uptime        prometheus.Gauge
-}
-
-// NewPipelineMetrics creates and registers pipeline metrics.
-func NewPipelineMetrics(reg prometheus.Registerer) *PipelineMetrics {
-	m := &PipelineMetrics{
-		JobsProcessed: prometheus.NewCounterVec(
-			prometheus.CounterOpts{
-				Name: "vocnet_pipeline_jobs_processed_total",
-				Help: "Total number of pipeline jobs processed",
-			},
-			[]string{"status"}, // "succeeded" or "failed"
-		),
-		JobsTotal: prometheus.NewGaugeVec(
-			prometheus.GaugeOpts{
-				Name: "vocnet_pipeline_queue_jobs",
-				Help: "Number of jobs in queue by status",
-			},
-			[]string{"status"}, // "pending", "running", "completed", "failed", "paused", "cancelled"
-		),
-		JobDuration: prometheus.NewHistogram(
-			prometheus.HistogramOpts{
-				Name:    "vocnet_pipeline_job_duration_seconds",
-				Help:    "Duration of pipeline job processing in seconds",
-				Buckets: prometheus.ExponentialBuckets(0.1, 2, 10), // 0.1s to ~100s
-			},
-		),
-		JobsPerMinute: prometheus.NewGauge(
-			prometheus.GaugeOpts{
-				Name: "vocnet_pipeline_jobs_per_minute",
-				Help: "Current rate of jobs per minute (1-min window)",
-			},
-		),
-		Uptime: prometheus.NewGauge(
-			prometheus.GaugeOpts{
-				Name: "vocnet_pipeline_uptime_seconds",
-				Help: "Worker pool uptime in seconds",
-			},
-		),
-	}
-
-	reg.MustRegister(m.JobsProcessed)
-	reg.MustRegister(m.JobsTotal)
-	reg.MustRegister(m.JobDuration)
-	reg.MustRegister(m.JobsPerMinute)
-	reg.MustRegister(m.Uptime)
-
-	return m
-}
-
 // MetricsHandler returns an http.Handler for the /metrics endpoint.
+// Metrics are registered by pipeline.WorkerPoolMetrics to the default registry.
 func MetricsHandler() http.Handler {
 	return promhttp.Handler()
-}
-
-// MetricsHandlerFor returns an http.Handler for a custom registry.
-func MetricsHandlerFor(reg *prometheus.Registry) http.Handler {
-	return promhttp.HandlerFor(reg, promhttp.HandlerOpts{})
 }

--- a/internal/infrastructure/server/metrics.go
+++ b/internal/infrastructure/server/metrics.go
@@ -1,124 +1,74 @@
 package server
 
 import (
-	"encoding/json"
 	"net/http"
 
-	"github.com/eslsoft/vocnet/internal/entity"
-	"github.com/eslsoft/vocnet/internal/repository"
-	"github.com/eslsoft/vocnet/internal/usecase/pipeline"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
-// PipelineMetricsProvider provides metrics from the pipeline worker pool.
-type PipelineMetricsProvider interface {
-	Metrics() pipeline.MetricsSnapshot
+// PipelineMetrics holds Prometheus metrics for the pipeline worker pool.
+type PipelineMetrics struct {
+	JobsProcessed *prometheus.CounterVec
+	JobsTotal     *prometheus.GaugeVec
+	JobDuration   prometheus.Histogram
+	JobsPerMinute prometheus.Gauge
+	Uptime        prometheus.Gauge
 }
 
-// PipelineStatsResponse is the full stats response including queue info.
-type PipelineStatsResponse struct {
-	// Worker pool metrics
-	Worker pipeline.MetricsSnapshot `json:"worker"`
+// NewPipelineMetrics creates and registers pipeline metrics.
+func NewPipelineMetrics(reg prometheus.Registerer) *PipelineMetrics {
+	m := &PipelineMetrics{
+		JobsProcessed: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "vocnet_pipeline_jobs_processed_total",
+				Help: "Total number of pipeline jobs processed",
+			},
+			[]string{"status"}, // "succeeded" or "failed"
+		),
+		JobsTotal: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name: "vocnet_pipeline_queue_jobs",
+				Help: "Number of jobs in queue by status",
+			},
+			[]string{"status"}, // "pending", "running", "completed", "failed", "paused", "cancelled"
+		),
+		JobDuration: prometheus.NewHistogram(
+			prometheus.HistogramOpts{
+				Name:    "vocnet_pipeline_job_duration_seconds",
+				Help:    "Duration of pipeline job processing in seconds",
+				Buckets: prometheus.ExponentialBuckets(0.1, 2, 10), // 0.1s to ~100s
+			},
+		),
+		JobsPerMinute: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Name: "vocnet_pipeline_jobs_per_minute",
+				Help: "Current rate of jobs per minute (1-min window)",
+			},
+		),
+		Uptime: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Name: "vocnet_pipeline_uptime_seconds",
+				Help: "Worker pool uptime in seconds",
+			},
+		),
+	}
 
-	// Queue status (from database)
-	Queue QueueStats `json:"queue"`
+	reg.MustRegister(m.JobsProcessed)
+	reg.MustRegister(m.JobsTotal)
+	reg.MustRegister(m.JobDuration)
+	reg.MustRegister(m.JobsPerMinute)
+	reg.MustRegister(m.Uptime)
 
-	// Estimated time remaining
-	EstimatedRemainingSeconds float64 `json:"estimated_remaining_seconds,omitempty"`
+	return m
 }
 
-// QueueStats contains job queue statistics.
-type QueueStats struct {
-	Pending   int64 `json:"pending"`
-	Running   int64 `json:"running"`
-	Completed int64 `json:"completed"`
-	Failed    int64 `json:"failed"`
-	Paused    int64 `json:"paused"`
-	Cancelled int64 `json:"cancelled"`
-	Total     int64 `json:"total"`
+// MetricsHandler returns an http.Handler for the /metrics endpoint.
+func MetricsHandler() http.Handler {
+	return promhttp.Handler()
 }
 
-// MetricsHandler handles the /metrics/pipeline endpoint.
-type MetricsHandler struct {
-	metricsProvider PipelineMetricsProvider
-	jobRepo         repository.PipelineJobRepository
-}
-
-// NewMetricsHandler creates a new metrics handler.
-func NewMetricsHandler(provider PipelineMetricsProvider, jobRepo repository.PipelineJobRepository) *MetricsHandler {
-	return &MetricsHandler{
-		metricsProvider: provider,
-		jobRepo:         jobRepo,
-	}
-}
-
-// ServeHTTP handles metrics requests.
-func (h *MetricsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodGet {
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
-		return
-	}
-
-	ctx := r.Context()
-
-	// Get worker metrics
-	var workerMetrics pipeline.MetricsSnapshot
-	if h.metricsProvider != nil {
-		workerMetrics = h.metricsProvider.Metrics()
-	}
-
-	// Get queue stats from database
-	queueStats := QueueStats{}
-	if h.jobRepo != nil {
-		statuses := []entity.JobStatus{
-			entity.JobStatusPending,
-			entity.JobStatusRunning,
-			entity.JobStatusCompleted,
-			entity.JobStatusFailed,
-			entity.JobStatusPaused,
-			entity.JobStatusCancelled,
-		}
-
-		for _, status := range statuses {
-			s := status
-			jobs, err := h.jobRepo.List(ctx, &s, 0) // 0 = no limit, just count
-			if err != nil {
-				continue
-			}
-			count := int64(len(jobs))
-			queueStats.Total += count
-
-			switch status {
-			case entity.JobStatusPending:
-				queueStats.Pending = count
-			case entity.JobStatusRunning:
-				queueStats.Running = count
-			case entity.JobStatusCompleted:
-				queueStats.Completed = count
-			case entity.JobStatusFailed:
-				queueStats.Failed = count
-			case entity.JobStatusPaused:
-				queueStats.Paused = count
-			case entity.JobStatusCancelled:
-				queueStats.Cancelled = count
-			}
-		}
-	}
-
-	// Calculate estimated remaining time
-	var estimatedRemaining float64
-	remaining := queueStats.Pending + queueStats.Running
-	if remaining > 0 && workerMetrics.RecentJobsPerMinute > 0 {
-		estimatedRemaining = float64(remaining) / workerMetrics.RecentJobsPerMinute * 60 // convert to seconds
-	}
-
-	response := PipelineStatsResponse{
-		Worker:                    workerMetrics,
-		Queue:                     queueStats,
-		EstimatedRemainingSeconds: estimatedRemaining,
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	if err := json.NewEncoder(w).Encode(response); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-	}
+// MetricsHandlerFor returns an http.Handler for a custom registry.
+func MetricsHandlerFor(reg *prometheus.Registry) http.Handler {
+	return promhttp.HandlerFor(reg, promhttp.HandlerOpts{})
 }

--- a/internal/infrastructure/server/metrics.go
+++ b/internal/infrastructure/server/metrics.go
@@ -1,0 +1,124 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/eslsoft/vocnet/internal/entity"
+	"github.com/eslsoft/vocnet/internal/repository"
+	"github.com/eslsoft/vocnet/internal/usecase/pipeline"
+)
+
+// PipelineMetricsProvider provides metrics from the pipeline worker pool.
+type PipelineMetricsProvider interface {
+	Metrics() pipeline.MetricsSnapshot
+}
+
+// PipelineStatsResponse is the full stats response including queue info.
+type PipelineStatsResponse struct {
+	// Worker pool metrics
+	Worker pipeline.MetricsSnapshot `json:"worker"`
+
+	// Queue status (from database)
+	Queue QueueStats `json:"queue"`
+
+	// Estimated time remaining
+	EstimatedRemainingSeconds float64 `json:"estimated_remaining_seconds,omitempty"`
+}
+
+// QueueStats contains job queue statistics.
+type QueueStats struct {
+	Pending   int64 `json:"pending"`
+	Running   int64 `json:"running"`
+	Completed int64 `json:"completed"`
+	Failed    int64 `json:"failed"`
+	Paused    int64 `json:"paused"`
+	Cancelled int64 `json:"cancelled"`
+	Total     int64 `json:"total"`
+}
+
+// MetricsHandler handles the /metrics/pipeline endpoint.
+type MetricsHandler struct {
+	metricsProvider PipelineMetricsProvider
+	jobRepo         repository.PipelineJobRepository
+}
+
+// NewMetricsHandler creates a new metrics handler.
+func NewMetricsHandler(provider PipelineMetricsProvider, jobRepo repository.PipelineJobRepository) *MetricsHandler {
+	return &MetricsHandler{
+		metricsProvider: provider,
+		jobRepo:         jobRepo,
+	}
+}
+
+// ServeHTTP handles metrics requests.
+func (h *MetricsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	ctx := r.Context()
+
+	// Get worker metrics
+	var workerMetrics pipeline.MetricsSnapshot
+	if h.metricsProvider != nil {
+		workerMetrics = h.metricsProvider.Metrics()
+	}
+
+	// Get queue stats from database
+	queueStats := QueueStats{}
+	if h.jobRepo != nil {
+		statuses := []entity.JobStatus{
+			entity.JobStatusPending,
+			entity.JobStatusRunning,
+			entity.JobStatusCompleted,
+			entity.JobStatusFailed,
+			entity.JobStatusPaused,
+			entity.JobStatusCancelled,
+		}
+
+		for _, status := range statuses {
+			s := status
+			jobs, err := h.jobRepo.List(ctx, &s, 0) // 0 = no limit, just count
+			if err != nil {
+				continue
+			}
+			count := int64(len(jobs))
+			queueStats.Total += count
+
+			switch status {
+			case entity.JobStatusPending:
+				queueStats.Pending = count
+			case entity.JobStatusRunning:
+				queueStats.Running = count
+			case entity.JobStatusCompleted:
+				queueStats.Completed = count
+			case entity.JobStatusFailed:
+				queueStats.Failed = count
+			case entity.JobStatusPaused:
+				queueStats.Paused = count
+			case entity.JobStatusCancelled:
+				queueStats.Cancelled = count
+			}
+		}
+	}
+
+	// Calculate estimated remaining time
+	var estimatedRemaining float64
+	remaining := queueStats.Pending + queueStats.Running
+	if remaining > 0 && workerMetrics.RecentJobsPerMinute > 0 {
+		estimatedRemaining = float64(remaining) / workerMetrics.RecentJobsPerMinute * 60 // convert to seconds
+	}
+
+	response := PipelineStatsResponse{
+		Worker:                    workerMetrics,
+		Queue:                     queueStats,
+		EstimatedRemainingSeconds: estimatedRemaining,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}

--- a/internal/infrastructure/server/metrics.go
+++ b/internal/infrastructure/server/metrics.go
@@ -3,11 +3,37 @@ package server
 import (
 	"net/http"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
+var (
+	// HTTPRequestsTotal counts total HTTP requests by method and path.
+	HTTPRequestsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "vocnet_http_requests_total",
+			Help: "Total number of HTTP requests",
+		},
+		[]string{"method", "path", "status"},
+	)
+
+	// HTTPRequestDuration tracks HTTP request latency.
+	HTTPRequestDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "vocnet_http_request_duration_seconds",
+			Help:    "HTTP request latency in seconds",
+			Buckets: prometheus.DefBuckets,
+		},
+		[]string{"method", "path"},
+	)
+)
+
+func init() {
+	prometheus.MustRegister(HTTPRequestsTotal)
+	prometheus.MustRegister(HTTPRequestDuration)
+}
+
 // MetricsHandler returns an http.Handler for the /metrics endpoint.
-// Metrics are registered by pipeline.WorkerPoolMetrics to the default registry.
 func MetricsHandler() http.Handler {
 	return promhttp.Handler()
 }

--- a/internal/infrastructure/server/server.go
+++ b/internal/infrastructure/server/server.go
@@ -28,6 +28,7 @@ type Server struct {
 	config       *config.Config
 	grpcServer   *grpc.Server
 	httpServer   *http.Server
+	httpMux      *http.ServeMux
 	logger       *slog.Logger
 	jwtValidator *auth.JWTValidator
 }
@@ -64,7 +65,8 @@ func NewServer(cfg *config.Config, logger *slog.Logger, jwtValidator *auth.JWTVa
 	mux.Handle(learningv1connect.NewStatsServiceHandler(statsSvc, interceptors))
 
 	return &Server{
-		config: cfg,
+		config:  cfg,
+		httpMux: mux,
 		httpServer: &http.Server{
 			Addr:              fmt.Sprintf(":%d", cfg.Server.HTTPPort),
 			Handler:           h2c.NewHandler(withCORS(mux), &http2.Server{}),
@@ -103,6 +105,11 @@ func (s *Server) StartHTTP() error {
 	}
 
 	return nil
+}
+
+// RegisterMetricsHandler registers the metrics endpoint.
+func (s *Server) RegisterMetricsHandler(handler http.Handler) {
+	s.httpMux.Handle("/metrics/pipeline", handler)
 }
 
 // Shutdown gracefully shuts down the server

--- a/internal/infrastructure/server/server.go
+++ b/internal/infrastructure/server/server.go
@@ -109,7 +109,7 @@ func (s *Server) StartHTTP() error {
 
 // RegisterMetricsHandler registers the metrics endpoint.
 func (s *Server) RegisterMetricsHandler(handler http.Handler) {
-	s.httpMux.Handle("/metrics/pipeline", handler)
+	s.httpMux.Handle("/metrics", handler)
 }
 
 // Shutdown gracefully shuts down the server

--- a/internal/usecase/pipeline/metrics.go
+++ b/internal/usecase/pipeline/metrics.go
@@ -1,0 +1,160 @@
+package pipeline
+
+import (
+	"sync/atomic"
+	"time"
+)
+
+// WorkerPoolMetrics tracks worker pool performance metrics.
+type WorkerPoolMetrics struct {
+	// Counters
+	jobsProcessed atomic.Int64
+	jobsSucceeded atomic.Int64
+	jobsFailed    atomic.Int64
+
+	// Timing
+	startTime      time.Time
+	totalDurationNs atomic.Int64 // total processing duration in nanoseconds
+
+	// Rate tracking (sliding window)
+	recentJobs      []jobRecord
+	recentJobsMutex chan struct{} // simple mutex using channel
+}
+
+type jobRecord struct {
+	timestamp time.Time
+	durationNs int64
+	succeeded  bool
+}
+
+// NewWorkerPoolMetrics creates a new metrics collector.
+func NewWorkerPoolMetrics() *WorkerPoolMetrics {
+	return &WorkerPoolMetrics{
+		startTime:       time.Now(),
+		recentJobs:      make([]jobRecord, 0, 1000),
+		recentJobsMutex: make(chan struct{}, 1),
+	}
+}
+
+// RecordJob records a completed job.
+func (m *WorkerPoolMetrics) RecordJob(duration time.Duration, succeeded bool) {
+	m.jobsProcessed.Add(1)
+	if succeeded {
+		m.jobsSucceeded.Add(1)
+	} else {
+		m.jobsFailed.Add(1)
+	}
+	m.totalDurationNs.Add(duration.Nanoseconds())
+
+	// Add to recent jobs (for rate calculation)
+	record := jobRecord{
+		timestamp:  time.Now(),
+		durationNs: duration.Nanoseconds(),
+		succeeded:  succeeded,
+	}
+
+	m.recentJobsMutex <- struct{}{}
+	defer func() { <-m.recentJobsMutex }()
+
+	// Keep only last 5 minutes of records
+	cutoff := time.Now().Add(-5 * time.Minute)
+	filtered := make([]jobRecord, 0, len(m.recentJobs)+1)
+	for _, r := range m.recentJobs {
+		if r.timestamp.After(cutoff) {
+			filtered = append(filtered, r)
+		}
+	}
+	filtered = append(filtered, record)
+	m.recentJobs = filtered
+}
+
+// Snapshot returns a point-in-time snapshot of metrics.
+type MetricsSnapshot struct {
+	// Uptime
+	UptimeSeconds float64 `json:"uptime_seconds"`
+
+	// Job counts
+	JobsProcessed int64 `json:"jobs_processed"`
+	JobsSucceeded int64 `json:"jobs_succeeded"`
+	JobsFailed    int64 `json:"jobs_failed"`
+
+	// Rate (jobs per minute, based on last 5 minutes)
+	JobsPerMinute float64 `json:"jobs_per_minute"`
+
+	// Average duration
+	AvgDurationMs float64 `json:"avg_duration_ms"`
+
+	// Recent rate (last minute)
+	RecentJobsPerMinute float64 `json:"recent_jobs_per_minute"`
+	RecentAvgDurationMs float64 `json:"recent_avg_duration_ms"`
+}
+
+// Snapshot returns current metrics.
+func (m *WorkerPoolMetrics) Snapshot() MetricsSnapshot {
+	now := time.Now()
+	processed := m.jobsProcessed.Load()
+	succeeded := m.jobsSucceeded.Load()
+	failed := m.jobsFailed.Load()
+	totalDuration := m.totalDurationNs.Load()
+
+	snapshot := MetricsSnapshot{
+		UptimeSeconds: now.Sub(m.startTime).Seconds(),
+		JobsProcessed: processed,
+		JobsSucceeded: succeeded,
+		JobsFailed:    failed,
+	}
+
+	if processed > 0 {
+		snapshot.AvgDurationMs = float64(totalDuration) / float64(processed) / 1e6
+	}
+
+	// Calculate rates from recent jobs
+	m.recentJobsMutex <- struct{}{}
+	defer func() { <-m.recentJobsMutex }()
+
+	if len(m.recentJobs) > 0 {
+		cutoff5min := now.Add(-5 * time.Minute)
+		cutoff1min := now.Add(-1 * time.Minute)
+
+		var count5min, count1min int64
+		var duration5min, duration1min int64
+
+		for _, r := range m.recentJobs {
+			if r.timestamp.After(cutoff5min) {
+				count5min++
+				duration5min += r.durationNs
+			}
+			if r.timestamp.After(cutoff1min) {
+				count1min++
+				duration1min += r.durationNs
+			}
+		}
+
+		if count5min > 0 {
+			elapsed5min := now.Sub(cutoff5min).Minutes()
+			if elapsed5min > 0 {
+				snapshot.JobsPerMinute = float64(count5min) / elapsed5min
+			}
+		}
+
+		if count1min > 0 {
+			snapshot.RecentJobsPerMinute = float64(count1min)
+			snapshot.RecentAvgDurationMs = float64(duration1min) / float64(count1min) / 1e6
+		}
+	}
+
+	return snapshot
+}
+
+// Reset resets all metrics.
+func (m *WorkerPoolMetrics) Reset() {
+	m.jobsProcessed.Store(0)
+	m.jobsSucceeded.Store(0)
+	m.jobsFailed.Store(0)
+	m.totalDurationNs.Store(0)
+	m.startTime = time.Now()
+
+	m.recentJobsMutex <- struct{}{}
+	m.recentJobs = make([]jobRecord, 0, 1000)
+	<-m.recentJobsMutex
+}

--- a/internal/usecase/pipeline/metrics.go
+++ b/internal/usecase/pipeline/metrics.go
@@ -3,54 +3,103 @@ package pipeline
 import (
 	"sync/atomic"
 	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
 )
 
-// WorkerPoolMetrics tracks worker pool performance metrics.
+// WorkerPoolMetrics tracks worker pool performance metrics using Prometheus.
 type WorkerPoolMetrics struct {
-	// Counters
-	jobsProcessed atomic.Int64
-	jobsSucceeded atomic.Int64
-	jobsFailed    atomic.Int64
+	// Prometheus metrics
+	jobsProcessed *prometheus.CounterVec
+	jobDuration   prometheus.Histogram
+	jobsPerMinute prometheus.Gauge
+	uptime        prometheus.Gauge
 
-	// Timing
-	startTime      time.Time
-	totalDurationNs atomic.Int64 // total processing duration in nanoseconds
-
-	// Rate tracking (sliding window)
+	// Internal tracking for rate calculation
+	startTime       time.Time
 	recentJobs      []jobRecord
-	recentJobsMutex chan struct{} // simple mutex using channel
+	recentJobsMutex chan struct{}
+
+	// Atomic counters for snapshot
+	processed atomic.Int64
+	succeeded atomic.Int64
+	failed    atomic.Int64
 }
 
 type jobRecord struct {
-	timestamp time.Time
+	timestamp  time.Time
 	durationNs int64
-	succeeded  bool
 }
 
-// NewWorkerPoolMetrics creates a new metrics collector.
+// NewWorkerPoolMetrics creates a new metrics collector with Prometheus registration.
 func NewWorkerPoolMetrics() *WorkerPoolMetrics {
-	return &WorkerPoolMetrics{
+	return NewWorkerPoolMetricsWithRegistry(prometheus.DefaultRegisterer)
+}
+
+// NewWorkerPoolMetricsWithRegistry creates metrics with a custom registry (for testing).
+func NewWorkerPoolMetricsWithRegistry(reg prometheus.Registerer) *WorkerPoolMetrics {
+	m := &WorkerPoolMetrics{
+		jobsProcessed: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "vocnet_pipeline_jobs_processed_total",
+				Help: "Total number of pipeline jobs processed",
+			},
+			[]string{"status"},
+		),
+		jobDuration: prometheus.NewHistogram(
+			prometheus.HistogramOpts{
+				Name:    "vocnet_pipeline_job_duration_seconds",
+				Help:    "Duration of pipeline job processing in seconds",
+				Buckets: prometheus.ExponentialBuckets(0.1, 2, 10),
+			},
+		),
+		jobsPerMinute: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Name: "vocnet_pipeline_jobs_per_minute",
+				Help: "Current rate of jobs per minute (1-min window)",
+			},
+		),
+		uptime: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Name: "vocnet_pipeline_uptime_seconds",
+				Help: "Worker pool uptime in seconds",
+			},
+		),
 		startTime:       time.Now(),
 		recentJobs:      make([]jobRecord, 0, 1000),
 		recentJobsMutex: make(chan struct{}, 1),
 	}
+
+	if reg != nil {
+		reg.MustRegister(m.jobsProcessed)
+		reg.MustRegister(m.jobDuration)
+		reg.MustRegister(m.jobsPerMinute)
+		reg.MustRegister(m.uptime)
+	}
+
+	return m
 }
 
 // RecordJob records a completed job.
 func (m *WorkerPoolMetrics) RecordJob(duration time.Duration, succeeded bool) {
-	m.jobsProcessed.Add(1)
-	if succeeded {
-		m.jobsSucceeded.Add(1)
-	} else {
-		m.jobsFailed.Add(1)
-	}
-	m.totalDurationNs.Add(duration.Nanoseconds())
+	m.processed.Add(1)
 
-	// Add to recent jobs (for rate calculation)
+	status := "succeeded"
+	if succeeded {
+		m.succeeded.Add(1)
+	} else {
+		m.failed.Add(1)
+		status = "failed"
+	}
+
+	// Update Prometheus metrics
+	m.jobsProcessed.WithLabelValues(status).Inc()
+	m.jobDuration.Observe(duration.Seconds())
+
+	// Track for rate calculation
 	record := jobRecord{
 		timestamp:  time.Now(),
 		durationNs: duration.Nanoseconds(),
-		succeeded:  succeeded,
 	}
 
 	m.recentJobsMutex <- struct{}{}
@@ -66,36 +115,45 @@ func (m *WorkerPoolMetrics) RecordJob(duration time.Duration, succeeded bool) {
 	}
 	filtered = append(filtered, record)
 	m.recentJobs = filtered
+
+	// Update rate gauge
+	m.updateRateGauge()
 }
 
-// Snapshot returns a point-in-time snapshot of metrics.
+// updateRateGauge updates the jobs per minute gauge.
+func (m *WorkerPoolMetrics) updateRateGauge() {
+	now := time.Now()
+	cutoff1min := now.Add(-1 * time.Minute)
+
+	var count1min int64
+	for _, r := range m.recentJobs {
+		if r.timestamp.After(cutoff1min) {
+			count1min++
+		}
+	}
+
+	m.jobsPerMinute.Set(float64(count1min))
+	m.uptime.Set(now.Sub(m.startTime).Seconds())
+}
+
+// MetricsSnapshot is a point-in-time snapshot of metrics for CLI display.
 type MetricsSnapshot struct {
-	// Uptime
-	UptimeSeconds float64 `json:"uptime_seconds"`
-
-	// Job counts
-	JobsProcessed int64 `json:"jobs_processed"`
-	JobsSucceeded int64 `json:"jobs_succeeded"`
-	JobsFailed    int64 `json:"jobs_failed"`
-
-	// Rate (jobs per minute, based on last 5 minutes)
-	JobsPerMinute float64 `json:"jobs_per_minute"`
-
-	// Average duration
-	AvgDurationMs float64 `json:"avg_duration_ms"`
-
-	// Recent rate (last minute)
+	UptimeSeconds       float64 `json:"uptime_seconds"`
+	JobsProcessed       int64   `json:"jobs_processed"`
+	JobsSucceeded       int64   `json:"jobs_succeeded"`
+	JobsFailed          int64   `json:"jobs_failed"`
+	JobsPerMinute       float64 `json:"jobs_per_minute"`
+	AvgDurationMs       float64 `json:"avg_duration_ms"`
 	RecentJobsPerMinute float64 `json:"recent_jobs_per_minute"`
 	RecentAvgDurationMs float64 `json:"recent_avg_duration_ms"`
 }
 
-// Snapshot returns current metrics.
+// Snapshot returns current metrics for CLI display.
 func (m *WorkerPoolMetrics) Snapshot() MetricsSnapshot {
 	now := time.Now()
-	processed := m.jobsProcessed.Load()
-	succeeded := m.jobsSucceeded.Load()
-	failed := m.jobsFailed.Load()
-	totalDuration := m.totalDurationNs.Load()
+	processed := m.processed.Load()
+	succeeded := m.succeeded.Load()
+	failed := m.failed.Load()
 
 	snapshot := MetricsSnapshot{
 		UptimeSeconds: now.Sub(m.startTime).Seconds(),
@@ -104,11 +162,6 @@ func (m *WorkerPoolMetrics) Snapshot() MetricsSnapshot {
 		JobsFailed:    failed,
 	}
 
-	if processed > 0 {
-		snapshot.AvgDurationMs = float64(totalDuration) / float64(processed) / 1e6
-	}
-
-	// Calculate rates from recent jobs
 	m.recentJobsMutex <- struct{}{}
 	defer func() { <-m.recentJobsMutex }()
 
@@ -135,6 +188,7 @@ func (m *WorkerPoolMetrics) Snapshot() MetricsSnapshot {
 			if elapsed5min > 0 {
 				snapshot.JobsPerMinute = float64(count5min) / elapsed5min
 			}
+			snapshot.AvgDurationMs = float64(duration5min) / float64(count5min) / 1e6
 		}
 
 		if count1min > 0 {
@@ -148,13 +202,15 @@ func (m *WorkerPoolMetrics) Snapshot() MetricsSnapshot {
 
 // Reset resets all metrics.
 func (m *WorkerPoolMetrics) Reset() {
-	m.jobsProcessed.Store(0)
-	m.jobsSucceeded.Store(0)
-	m.jobsFailed.Store(0)
-	m.totalDurationNs.Store(0)
+	m.processed.Store(0)
+	m.succeeded.Store(0)
+	m.failed.Store(0)
 	m.startTime = time.Now()
 
 	m.recentJobsMutex <- struct{}{}
 	m.recentJobs = make([]jobRecord, 0, 1000)
 	<-m.recentJobsMutex
+
+	m.jobsPerMinute.Set(0)
+	m.uptime.Set(0)
 }

--- a/internal/usecase/pipeline/metrics_test.go
+++ b/internal/usecase/pipeline/metrics_test.go
@@ -3,10 +3,13 @@ package pipeline
 import (
 	"testing"
 	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 func TestWorkerPoolMetrics_RecordJob(t *testing.T) {
-	m := NewWorkerPoolMetrics()
+	reg := prometheus.NewRegistry()
+	m := NewWorkerPoolMetricsWithRegistry(reg)
 
 	// Record some successful jobs
 	m.RecordJob(100*time.Millisecond, true)
@@ -37,7 +40,8 @@ func TestWorkerPoolMetrics_RecordJob(t *testing.T) {
 }
 
 func TestWorkerPoolMetrics_RateCalculation(t *testing.T) {
-	m := NewWorkerPoolMetrics()
+	reg := prometheus.NewRegistry()
+	m := NewWorkerPoolMetricsWithRegistry(reg)
 
 	// Record 10 jobs quickly
 	for range 10 {
@@ -58,7 +62,8 @@ func TestWorkerPoolMetrics_RateCalculation(t *testing.T) {
 }
 
 func TestWorkerPoolMetrics_Reset(t *testing.T) {
-	m := NewWorkerPoolMetrics()
+	reg := prometheus.NewRegistry()
+	m := NewWorkerPoolMetricsWithRegistry(reg)
 
 	m.RecordJob(100*time.Millisecond, true)
 	m.RecordJob(100*time.Millisecond, false)

--- a/internal/usecase/pipeline/metrics_test.go
+++ b/internal/usecase/pipeline/metrics_test.go
@@ -1,0 +1,79 @@
+package pipeline
+
+import (
+	"testing"
+	"time"
+)
+
+func TestWorkerPoolMetrics_RecordJob(t *testing.T) {
+	m := NewWorkerPoolMetrics()
+
+	// Record some successful jobs
+	m.RecordJob(100*time.Millisecond, true)
+	m.RecordJob(200*time.Millisecond, true)
+	m.RecordJob(150*time.Millisecond, false)
+
+	snapshot := m.Snapshot()
+
+	if snapshot.JobsProcessed != 3 {
+		t.Errorf("expected 3 processed jobs, got %d", snapshot.JobsProcessed)
+	}
+	if snapshot.JobsSucceeded != 2 {
+		t.Errorf("expected 2 succeeded jobs, got %d", snapshot.JobsSucceeded)
+	}
+	if snapshot.JobsFailed != 1 {
+		t.Errorf("expected 1 failed job, got %d", snapshot.JobsFailed)
+	}
+
+	// Average should be (100+200+150)/3 = 150ms
+	expectedAvg := 150.0
+	if snapshot.AvgDurationMs < expectedAvg-1 || snapshot.AvgDurationMs > expectedAvg+1 {
+		t.Errorf("expected avg duration ~%.0f ms, got %.0f ms", expectedAvg, snapshot.AvgDurationMs)
+	}
+
+	if snapshot.UptimeSeconds <= 0 {
+		t.Error("expected positive uptime")
+	}
+}
+
+func TestWorkerPoolMetrics_RateCalculation(t *testing.T) {
+	m := NewWorkerPoolMetrics()
+
+	// Record 10 jobs quickly
+	for range 10 {
+		m.RecordJob(50*time.Millisecond, true)
+	}
+
+	snapshot := m.Snapshot()
+
+	// Jobs per minute should be > 0 since we just recorded jobs
+	if snapshot.RecentJobsPerMinute <= 0 {
+		t.Errorf("expected positive recent rate, got %.2f", snapshot.RecentJobsPerMinute)
+	}
+
+	// Should equal 10 since all were recorded in the last minute
+	if snapshot.RecentJobsPerMinute != 10 {
+		t.Errorf("expected recent rate of 10 jobs/min, got %.2f", snapshot.RecentJobsPerMinute)
+	}
+}
+
+func TestWorkerPoolMetrics_Reset(t *testing.T) {
+	m := NewWorkerPoolMetrics()
+
+	m.RecordJob(100*time.Millisecond, true)
+	m.RecordJob(100*time.Millisecond, false)
+
+	m.Reset()
+
+	snapshot := m.Snapshot()
+
+	if snapshot.JobsProcessed != 0 {
+		t.Errorf("expected 0 processed jobs after reset, got %d", snapshot.JobsProcessed)
+	}
+	if snapshot.JobsSucceeded != 0 {
+		t.Errorf("expected 0 succeeded jobs after reset, got %d", snapshot.JobsSucceeded)
+	}
+	if snapshot.JobsFailed != 0 {
+		t.Errorf("expected 0 failed jobs after reset, got %d", snapshot.JobsFailed)
+	}
+}

--- a/internal/usecase/pipeline/worker.go
+++ b/internal/usecase/pipeline/worker.go
@@ -13,8 +13,9 @@ import (
 
 // WorkerPoolConfig configures the worker pool.
 type WorkerPoolConfig struct {
-	WorkerCount  int           // Number of concurrent workers (default: 1)
-	PollInterval time.Duration // Interval between job polls (default: 5s)
+	WorkerCount       int           // Number of concurrent workers (default: 1)
+	PollInterval      time.Duration // Interval between job polls (default: 5s)
+	ProgressLogInterval time.Duration // Interval between progress logs (default: 30s, 0 to disable)
 }
 
 // WorkerPool manages concurrent pipeline job processing using gammazero/workerpool.
@@ -24,9 +25,10 @@ type WorkerPool struct {
 	logger   *slog.Logger
 	config   WorkerPoolConfig
 
-	pool   *workerpool.WorkerPool
-	cancel context.CancelFunc
-	done   chan struct{} // signals when Start() has fully completed
+	pool    *workerpool.WorkerPool
+	cancel  context.CancelFunc
+	done    chan struct{} // signals when Start() has fully completed
+	metrics *WorkerPoolMetrics
 }
 
 // NewWorkerPool creates a new worker pool with the given configuration.
@@ -42,6 +44,9 @@ func NewWorkerPool(
 	if config.PollInterval <= 0 {
 		config.PollInterval = 5 * time.Second
 	}
+	if config.ProgressLogInterval == 0 {
+		config.ProgressLogInterval = 30 * time.Second
+	}
 
 	return &WorkerPool{
 		jobRepo:  jobRepo,
@@ -49,6 +54,7 @@ func NewWorkerPool(
 		logger:   logger.With("component", "pipeline-worker-pool"),
 		config:   config,
 		done:     make(chan struct{}),
+		metrics:  NewWorkerPoolMetrics(),
 	}
 }
 
@@ -65,18 +71,30 @@ func (p *WorkerPool) Start(ctx context.Context) error {
 		"poll_interval", p.config.PollInterval.String(),
 	)
 
-	ticker := time.NewTicker(p.config.PollInterval)
-	defer ticker.Stop()
+	pollTicker := time.NewTicker(p.config.PollInterval)
+	defer pollTicker.Stop()
+
+	// Progress logging ticker (nil if disabled)
+	var progressTicker *time.Ticker
+	var progressCh <-chan time.Time
+	if p.config.ProgressLogInterval > 0 {
+		progressTicker = time.NewTicker(p.config.ProgressLogInterval)
+		progressCh = progressTicker.C
+		defer progressTicker.Stop()
+	}
 
 	for {
 		select {
 		case <-ctx.Done():
 			p.logger.Info("pipeline worker pool stopping, waiting for in-flight jobs...")
 			p.pool.StopWait()
+			p.logProgress() // Final progress report
 			p.logger.Info("pipeline worker pool stopped")
 			return nil
-		case <-ticker.C:
+		case <-pollTicker.C:
 			p.pollAndSubmit(ctx)
+		case <-progressCh:
+			p.logProgress()
 		}
 	}
 }
@@ -92,6 +110,34 @@ func (p *WorkerPool) Stop() {
 // Should be called after Stop() to ensure graceful shutdown.
 func (p *WorkerPool) Wait() {
 	<-p.done
+}
+
+// Metrics returns the current metrics snapshot.
+func (p *WorkerPool) Metrics() MetricsSnapshot {
+	return p.metrics.Snapshot()
+}
+
+// GetMetrics returns the underlying metrics collector (for external access).
+func (p *WorkerPool) GetMetrics() *WorkerPoolMetrics {
+	return p.metrics
+}
+
+// logProgress logs the current progress metrics.
+func (p *WorkerPool) logProgress() {
+	m := p.metrics.Snapshot()
+	if m.JobsProcessed == 0 {
+		return // Nothing to report
+	}
+
+	p.logger.Info("pipeline progress",
+		"processed", m.JobsProcessed,
+		"succeeded", m.JobsSucceeded,
+		"failed", m.JobsFailed,
+		"rate_per_min", m.JobsPerMinute,
+		"recent_rate_per_min", m.RecentJobsPerMinute,
+		"avg_duration_ms", m.AvgDurationMs,
+		"uptime_s", m.UptimeSeconds,
+	)
 }
 
 func (p *WorkerPool) pollAndSubmit(ctx context.Context) {
@@ -158,14 +204,17 @@ func (p *WorkerPool) processJob(ctx context.Context, job *entity.PipelineJob, jo
 	termLogger := jobLogger.With("term", term)
 	termStart := time.Now()
 	_, err = p.pipeline.Run(ctx, job.ID, term, job.Language, job.Tier, &RunOptions{Logger: termLogger})
+	duration := time.Since(termStart)
 	if err != nil {
+		p.metrics.RecordJob(duration, false)
 		_ = p.jobRepo.IncrementFailed(ctx, job.ID)
 		_ = p.jobRepo.UpdateStatus(ctx, job.ID, entity.JobStatusFailed, err.Error())
 		termLogger.Warn("failed to process term", "error", err)
 		return
 	}
 
+	p.metrics.RecordJob(duration, true)
 	_ = p.jobRepo.IncrementProcessed(ctx, job.ID)
 	_ = p.jobRepo.UpdateStatus(ctx, job.ID, entity.JobStatusCompleted, "")
-	jobLogger.Info("job completed", "duration", time.Since(jobStart).String(), "processed", 1, "failed", 0, "term_duration", time.Since(termStart).String())
+	jobLogger.Info("job completed", "duration", time.Since(jobStart).String(), "processed", 1, "failed", 0, "term_duration", duration.String())
 }


### PR DESCRIPTION
## Summary

Add comprehensive Prometheus metrics and CLI monitoring for the pipeline worker pool to track job processing progress and performance.

## Changes

### Prometheus Metrics (`/metrics` endpoint)
- `vocnet_pipeline_jobs_processed_total{status}` - Counter for succeeded/failed jobs
- `vocnet_pipeline_job_duration_seconds` - Histogram for job processing latency
- `vocnet_pipeline_jobs_per_minute` - Gauge for current processing rate (1-min window)
- `vocnet_pipeline_uptime_seconds` - Gauge for worker pool uptime
- `vocnet_http_requests_total{method,path,status}` - HTTP request counter (placeholder)
- `vocnet_http_request_duration_seconds{method,path}` - HTTP latency histogram (placeholder)

### CLI Stats Command
```bash
# One-time stats view
go run . pipeline stats

# Real-time monitoring (2s refresh)
go run . pipeline stats -w

# Custom server URL
go run . pipeline stats --url http://localhost:8080
```

### Periodic Progress Logging
- WorkerPool logs progress every 30s (configurable via `ProgressLogInterval`)
- Logs include: processed count, success/fail breakdown, rate, avg duration

## Why

When submitting thousands of jobs to the pipeline, users need visibility into:
- Current processing speed (jobs/min)
- How many jobs have been processed
- Estimated time remaining
- Success/failure rates

This enables both real-time CLI monitoring and integration with Prometheus/Grafana for production observability.

## Implementation Details

- Uses `prometheus/client_golang` SDK for standard Prometheus format
- Metrics are registered to the default Prometheus registry on WorkerPool creation
- CLI parses Prometheus text format to display human-readable stats
- Sliding window (5-min) for rate calculation with 1-min recent rate

---

This PR was written using [Vibe Kanban](https://vibekanban.com)