### PR TITLE
Fix pipeline job claiming to match worker capacity (Vibe Kanban)

### DIFF
--- a/internal/usecase/pipeline/metrics.go
+++ b/internal/usecase/pipeline/metrics.go
@@ -1,7 +1,6 @@
 package pipeline
 
 import (
-	"errors"
 	"sync/atomic"
 	"time"
 
@@ -80,11 +79,11 @@ func NewWorkerPoolMetricsWithRegistry(reg prometheus.Registerer) *WorkerPoolMetr
 	}
 
 	if reg != nil {
-		m.jobsProcessed = registerOrReuseCounterVec(reg, m.jobsProcessed)
-		m.jobDuration = registerOrReuseHistogram(reg, m.jobDuration)
-		m.jobsPerMinute = registerOrReuseGauge(reg, m.jobsPerMinute)
-		m.pendingJobs = registerOrReuseGauge(reg, m.pendingJobs)
-		m.uptime = registerOrReuseGauge(reg, m.uptime)
+		reg.MustRegister(m.jobsProcessed)
+		reg.MustRegister(m.jobDuration)
+		reg.MustRegister(m.jobsPerMinute)
+		reg.MustRegister(m.pendingJobs)
+		reg.MustRegister(m.uptime)
 	}
 
 	return m
@@ -232,49 +231,4 @@ func (m *WorkerPoolMetrics) Reset() {
 
 	m.jobsPerMinute.Set(0)
 	m.uptime.Set(0)
-}
-
-func registerOrReuseCounterVec(reg prometheus.Registerer, collector *prometheus.CounterVec) *prometheus.CounterVec {
-	if err := reg.Register(collector); err != nil {
-		var already prometheus.AlreadyRegisteredError
-		if errors.As(err, &already) {
-			existing, ok := already.ExistingCollector.(*prometheus.CounterVec)
-			if !ok {
-				panic(err)
-			}
-			return existing
-		}
-		panic(err)
-	}
-	return collector
-}
-
-func registerOrReuseHistogram(reg prometheus.Registerer, collector prometheus.Histogram) prometheus.Histogram {
-	if err := reg.Register(collector); err != nil {
-		var already prometheus.AlreadyRegisteredError
-		if errors.As(err, &already) {
-			existing, ok := already.ExistingCollector.(prometheus.Histogram)
-			if !ok {
-				panic(err)
-			}
-			return existing
-		}
-		panic(err)
-	}
-	return collector
-}
-
-func registerOrReuseGauge(reg prometheus.Registerer, collector prometheus.Gauge) prometheus.Gauge {
-	if err := reg.Register(collector); err != nil {
-		var already prometheus.AlreadyRegisteredError
-		if errors.As(err, &already) {
-			existing, ok := already.ExistingCollector.(prometheus.Gauge)
-			if !ok {
-				panic(err)
-			}
-			return existing
-		}
-		panic(err)
-	}
-	return collector
 }

--- a/internal/usecase/pipeline/metrics.go
+++ b/internal/usecase/pipeline/metrics.go
@@ -1,6 +1,7 @@
 package pipeline
 
 import (
+	"errors"
 	"sync/atomic"
 	"time"
 
@@ -79,11 +80,11 @@ func NewWorkerPoolMetricsWithRegistry(reg prometheus.Registerer) *WorkerPoolMetr
 	}
 
 	if reg != nil {
-		reg.MustRegister(m.jobsProcessed)
-		reg.MustRegister(m.jobDuration)
-		reg.MustRegister(m.jobsPerMinute)
-		reg.MustRegister(m.pendingJobs)
-		reg.MustRegister(m.uptime)
+		m.jobsProcessed = registerOrReuseCounterVec(reg, m.jobsProcessed)
+		m.jobDuration = registerOrReuseHistogram(reg, m.jobDuration)
+		m.jobsPerMinute = registerOrReuseGauge(reg, m.jobsPerMinute)
+		m.pendingJobs = registerOrReuseGauge(reg, m.pendingJobs)
+		m.uptime = registerOrReuseGauge(reg, m.uptime)
 	}
 
 	return m
@@ -231,4 +232,49 @@ func (m *WorkerPoolMetrics) Reset() {
 
 	m.jobsPerMinute.Set(0)
 	m.uptime.Set(0)
+}
+
+func registerOrReuseCounterVec(reg prometheus.Registerer, collector *prometheus.CounterVec) *prometheus.CounterVec {
+	if err := reg.Register(collector); err != nil {
+		var already prometheus.AlreadyRegisteredError
+		if errors.As(err, &already) {
+			existing, ok := already.ExistingCollector.(*prometheus.CounterVec)
+			if !ok {
+				panic(err)
+			}
+			return existing
+		}
+		panic(err)
+	}
+	return collector
+}
+
+func registerOrReuseHistogram(reg prometheus.Registerer, collector prometheus.Histogram) prometheus.Histogram {
+	if err := reg.Register(collector); err != nil {
+		var already prometheus.AlreadyRegisteredError
+		if errors.As(err, &already) {
+			existing, ok := already.ExistingCollector.(prometheus.Histogram)
+			if !ok {
+				panic(err)
+			}
+			return existing
+		}
+		panic(err)
+	}
+	return collector
+}
+
+func registerOrReuseGauge(reg prometheus.Registerer, collector prometheus.Gauge) prometheus.Gauge {
+	if err := reg.Register(collector); err != nil {
+		var already prometheus.AlreadyRegisteredError
+		if errors.As(err, &already) {
+			existing, ok := already.ExistingCollector.(prometheus.Gauge)
+			if !ok {
+				panic(err)
+			}
+			return existing
+		}
+		panic(err)
+	}
+	return collector
 }

--- a/internal/usecase/pipeline/worker.go
+++ b/internal/usecase/pipeline/worker.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/gammazero/workerpool"
+	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/eslsoft/vocnet/internal/entity"
 	"github.com/eslsoft/vocnet/internal/repository"
@@ -14,9 +15,10 @@ import (
 
 // WorkerPoolConfig configures the worker pool.
 type WorkerPoolConfig struct {
-	WorkerCount       int           // Number of concurrent workers (default: 1)
-	PollInterval      time.Duration // Interval between job polls (default: 5s)
-	ProgressLogInterval time.Duration // Interval between progress logs (default: 30s, 0 to disable)
+	WorkerCount         int                   // Number of concurrent workers (default: 1)
+	PollInterval        time.Duration         // Interval between job polls (default: 5s)
+	ProgressLogInterval time.Duration         // Interval between progress logs (default: 30s, 0 to disable)
+	MetricsRegisterer   prometheus.Registerer // Metrics registry (default: prometheus.DefaultRegisterer)
 }
 
 // WorkerPool manages concurrent pipeline job processing using gammazero/workerpool.
@@ -53,6 +55,9 @@ func NewWorkerPool(
 	if config.ProgressLogInterval == 0 {
 		config.ProgressLogInterval = 30 * time.Second
 	}
+	if config.MetricsRegisterer == nil {
+		config.MetricsRegisterer = prometheus.DefaultRegisterer
+	}
 
 	wp := &WorkerPool{
 		jobRepo:  jobRepo,
@@ -60,7 +65,7 @@ func NewWorkerPool(
 		logger:   logger.With("component", "pipeline-worker-pool"),
 		config:   config,
 		done:     make(chan struct{}),
-		metrics:  NewWorkerPoolMetrics(),
+		metrics:  NewWorkerPoolMetricsWithRegistry(config.MetricsRegisterer),
 	}
 	wp.processFn = wp.processJob
 	return wp

--- a/internal/usecase/pipeline/worker.go
+++ b/internal/usecase/pipeline/worker.go
@@ -3,6 +3,7 @@ package pipeline
 import (
 	"context"
 	"log/slog"
+	"sync/atomic"
 	"time"
 
 	"github.com/gammazero/workerpool"
@@ -29,6 +30,11 @@ type WorkerPool struct {
 	cancel  context.CancelFunc
 	done    chan struct{} // signals when Start() has fully completed
 	metrics *WorkerPoolMetrics
+
+	// inFlight tracks claimed jobs that are either running or queued inside the workerpool.
+	inFlight atomic.Int64
+
+	processFn func(context.Context, *entity.PipelineJob, *slog.Logger)
 }
 
 // NewWorkerPool creates a new worker pool with the given configuration.
@@ -48,7 +54,7 @@ func NewWorkerPool(
 		config.ProgressLogInterval = 30 * time.Second
 	}
 
-	return &WorkerPool{
+	wp := &WorkerPool{
 		jobRepo:  jobRepo,
 		pipeline: pipeline,
 		logger:   logger.With("component", "pipeline-worker-pool"),
@@ -56,6 +62,8 @@ func NewWorkerPool(
 		done:     make(chan struct{}),
 		metrics:  NewWorkerPoolMetrics(),
 	}
+	wp.processFn = wp.processJob
+	return wp
 }
 
 // Start begins the worker pool and polls for jobs.
@@ -150,8 +158,13 @@ func (p *WorkerPool) pollAndSubmit(ctx context.Context) {
 		p.metrics.SetPendingJobs(int64(count))
 	}
 
-	// Claim up to WorkerCount jobs to fill the pool
-	for range p.config.WorkerCount {
+	availableSlots := p.config.WorkerCount - int(p.inFlight.Load())
+	if availableSlots <= 0 {
+		return
+	}
+
+	// Claim only enough jobs to fill currently available worker slots.
+	for range availableSlots {
 		job, err := p.jobRepo.ClaimNext(ctx)
 		if err != nil {
 			p.logger.Error("failed to claim job", "error", err)
@@ -165,9 +178,11 @@ func (p *WorkerPool) pollAndSubmit(ctx context.Context) {
 		jobLogger.Info("submitting job to pool", "name", job.Name, "type", job.JobType)
 
 		// Submit job to worker pool - capture loop variables
+		p.inFlight.Add(1)
 		j, jl := job, jobLogger
 		p.pool.Submit(func() {
-			p.processJob(ctx, j, jl)
+			defer p.inFlight.Add(-1)
+			p.processFn(ctx, j, jl)
 		})
 	}
 }

--- a/internal/usecase/pipeline/worker_concurrency_test.go
+++ b/internal/usecase/pipeline/worker_concurrency_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/gammazero/workerpool"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 
 	"github.com/eslsoft/vocnet/internal/entity"
@@ -84,7 +85,8 @@ func TestWorkerPoolPollAndSubmit_ClaimBoundedByAvailableSlots(t *testing.T) {
 
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	pool := NewWorkerPool(repo, nil, logger, WorkerPoolConfig{
-		WorkerCount: 2,
+		WorkerCount:       2,
+		MetricsRegisterer: prometheus.NewRegistry(),
 	})
 	pool.pool = workerpool.New(2)
 	defer pool.pool.StopWait()

--- a/internal/usecase/pipeline/worker_concurrency_test.go
+++ b/internal/usecase/pipeline/worker_concurrency_test.go
@@ -1,0 +1,124 @@
+package pipeline
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gammazero/workerpool"
+	"github.com/stretchr/testify/require"
+
+	"github.com/eslsoft/vocnet/internal/entity"
+)
+
+type claimOnlyJobRepo struct {
+	mu      sync.Mutex
+	pending []*entity.PipelineJob
+	claimed int
+}
+
+func (r *claimOnlyJobRepo) Create(context.Context, *entity.PipelineJob) (*entity.PipelineJob, error) {
+	panic("not implemented")
+}
+
+func (r *claimOnlyJobRepo) GetByID(context.Context, int64) (*entity.PipelineJob, error) {
+	panic("not implemented")
+}
+
+func (r *claimOnlyJobRepo) List(context.Context, *entity.JobStatus, int) ([]*entity.PipelineJob, error) {
+	panic("not implemented")
+}
+
+func (r *claimOnlyJobRepo) ClaimNext(context.Context) (*entity.PipelineJob, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if len(r.pending) == 0 {
+		return nil, nil
+	}
+	job := r.pending[0]
+	r.pending = r.pending[1:]
+	r.claimed++
+	return job, nil
+}
+
+func (r *claimOnlyJobRepo) IncrementProcessed(context.Context, int64) error {
+	return nil
+}
+
+func (r *claimOnlyJobRepo) IncrementSkipped(context.Context, int64) error {
+	return nil
+}
+
+func (r *claimOnlyJobRepo) IncrementFailed(context.Context, int64) error {
+	return nil
+}
+
+func (r *claimOnlyJobRepo) UpdateStatus(context.Context, int64, entity.JobStatus, string) error {
+	return nil
+}
+
+func (r *claimOnlyJobRepo) CountByStatus(context.Context, entity.JobStatus) (int, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.pending), nil
+}
+
+func (r *claimOnlyJobRepo) ChangeStatus(context.Context, int64, entity.JobAction) error {
+	panic("not implemented")
+}
+
+func TestWorkerPoolPollAndSubmit_ClaimBoundedByAvailableSlots(t *testing.T) {
+	repo := &claimOnlyJobRepo{
+		pending: []*entity.PipelineJob{
+			{ID: 1, Term: "one"},
+			{ID: 2, Term: "two"},
+			{ID: 3, Term: "three"},
+			{ID: 4, Term: "four"},
+			{ID: 5, Term: "five"},
+		},
+	}
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	pool := NewWorkerPool(repo, nil, logger, WorkerPoolConfig{
+		WorkerCount: 2,
+	})
+	pool.pool = workerpool.New(2)
+	defer pool.pool.StopWait()
+
+	blockCh := make(chan struct{})
+	var started atomic.Int64
+	pool.processFn = func(_ context.Context, _ *entity.PipelineJob, _ *slog.Logger) {
+		started.Add(1)
+		<-blockCh
+	}
+
+	ctx := context.Background()
+	pool.pollAndSubmit(ctx)
+
+	require.Eventually(t, func() bool {
+		return started.Load() == 2
+	}, time.Second, 10*time.Millisecond)
+	require.Equal(t, 2, repo.claimed)
+
+	// Polling again while both slots are occupied should not claim more.
+	pool.pollAndSubmit(ctx)
+	require.Equal(t, 2, repo.claimed)
+
+	// Unblock current jobs and allow next polling cycle to claim more.
+	close(blockCh)
+	require.Eventually(t, func() bool {
+		return pool.inFlight.Load() == 0
+	}, time.Second, 10*time.Millisecond)
+
+	nextBlock := make(chan struct{})
+	pool.processFn = func(_ context.Context, _ *entity.PipelineJob, _ *slog.Logger) {
+		<-nextBlock
+	}
+	pool.pollAndSubmit(ctx)
+	require.Equal(t, 4, repo.claimed)
+	close(nextBlock)
+}

--- a/internal/usecase/pipeline/worker_test.go
+++ b/internal/usecase/pipeline/worker_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -54,8 +55,9 @@ func TestDeduplicateTerms(t *testing.T) {
 func TestWorkerPoolStop(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
 	pool := NewWorkerPool(nil, nil, logger, WorkerPoolConfig{
-		WorkerCount:  1,
-		PollInterval: time.Second,
+		WorkerCount:       1,
+		PollInterval:      time.Second,
+		MetricsRegisterer: prometheus.NewRegistry(),
 	})
 
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
## What Changed
- Updated pipeline worker scheduling so the pool only claims jobs when there are available worker slots.
- Added an in-flight counter in `WorkerPool` to track jobs that have already been claimed and are running/queued.
- Changed `pollAndSubmit` logic to compute `availableSlots = WorkerCount - inFlight` and claim at most that many jobs.
- Added a focused concurrency regression test (`TestWorkerPoolPollAndSubmit_ClaimBoundedByAvailableSlots`) that verifies repeated polling does not over-claim jobs while workers are busy.

## Why
The reported issue was that configured worker count and database `RUNNING` job count diverged significantly. The previous flow marked jobs `RUNNING` at claim time, but claims could happen faster than execution because workerpool queueing is non-blocking. This caused many jobs to be pre-claimed and shown as `RUNNING` even when not actively executing.

## Important Implementation Details
- `WorkerPool` now maintains an atomic `inFlight` counter.
- The counter is incremented immediately before submitting work to the workerpool and decremented with `defer` when the submitted task completes.
- Claiming is now bounded by currently available capacity (`WorkerCount - inFlight`), preventing unbounded pre-claim behavior during polling cycles.
- A `processFn` indirection was introduced to make the worker behavior testable in isolation.
- The new test uses a controlled fake repository and blocking channels to validate claim behavior under concurrent polling conditions.

This PR was written using [Vibe Kanban](https://vibekanban.com)
